### PR TITLE
ci: add commit-style PR validation

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,18 +1,12 @@
-## Summary
+**Summary**
 
+<overview of the change>
 
-## Changes
+**Changes**
 
+- <change 1>
+- <change 2>
 
-## Tests
+**Testing**
 
-
-## Risk
-
-
-## Checklist
-
-- [ ] Tests added or updated when behavior changed
-- [ ] Documentation updated when public API or behavior changed
-- [ ] Commit messages follow `CONTRIBUTING.md`
-- [ ] PR targets `main` and passes required CI
+<how the change was verified>

--- a/.github/workflows/validate.yml
+++ b/.github/workflows/validate.yml
@@ -1,0 +1,170 @@
+name: Validate PR
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+
+permissions:
+  contents: read
+  pull-requests: read
+
+jobs:
+  commit-style:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Validate PR title
+        env:
+          TITLE: ${{ github.event.pull_request.title }}
+        run: |
+          pattern='^(feat|fix|docs|style|refactor|perf|test|build|ci|chore|revert)(\([a-z0-9/._-]+\))?!?: .+'
+          if echo "$TITLE" | grep -qE "$pattern"; then
+            echo "✓ PR title is valid: $TITLE"
+          else
+            echo "✗ PR title does not follow conventional commits format."
+            echo "  Expected: type(scope): description"
+            echo "  Example:  feat(patterns): add rel_ops combinator"
+            echo "  Got:      $TITLE"
+            exit 1
+          fi
+
+      - name: Validate PR body
+        env:
+          BODY: ${{ github.event.pull_request.body }}
+        run: |
+          if [ -z "$BODY" ]; then
+            echo "✗ PR body is empty."
+            echo "  A description with the following sections is required:"
+            echo ""
+            echo "    **Summary**"
+            echo "    <overview of the change>"
+            echo ""
+            echo "    **Changes**"
+            echo "    - <change 1>"
+            echo "    - <change 2>"
+            echo ""
+            echo "    **Testing**"
+            echo "    <how the change was verified>"
+            exit 1
+          fi
+
+          body_len=$(printf '%s' "$BODY" | wc -c)
+          if [ "$body_len" -lt 50 ]; then
+            echo "✗ PR body is too short ($body_len chars, minimum 50 chars)."
+            echo "  A meaningful description helps reviewers and produces"
+            echo "  a readable squash merge commit message."
+            exit 1
+          fi
+
+          missing=""
+          if ! echo "$BODY" | grep -qi '^\*\*[Ss]ummary\*\*'; then
+            missing="$missing  **Summary**\n"
+          fi
+          if ! echo "$BODY" | grep -qi '^\*\*[Cc]hanges\*\*'; then
+            missing="$missing  **Changes**\n"
+          fi
+          if ! echo "$BODY" | grep -qi '^\*\*[Tt]esting\*\*'; then
+            missing="$missing  **Testing**\n"
+          fi
+
+          if [ -n "$missing" ]; then
+            echo "✗ PR body is missing required section(s):"
+            printf '%b' "$missing"
+            echo ""
+            echo "  Expected format:"
+            echo ""
+            echo "    **Summary**"
+            echo "    <overview of the change>"
+            echo ""
+            echo "    **Changes**"
+            echo "    - <change 1>"
+            echo "    - <change 2>"
+            echo ""
+            echo "    **Testing**"
+            echo "    <how the change was verified>"
+            exit 1
+          fi
+
+          echo "✓ PR body is valid ($body_len chars, all sections present)."
+
+      - name: Validate single commit
+        run: |
+          base_ref="${{ github.event.pull_request.base.sha }}"
+          count=$(git rev-list --count --no-merges "$base_ref..HEAD")
+
+          if [ "$count" -ne 1 ]; then
+            echo "✗ PR has $count commits; exactly 1 is required."
+            echo ""
+            echo "  Squash merge produces a brand-new commit object, so a"
+            echo "  multi-commit PR gets flattened anyway — but the merge"
+            echo "  commit then has no ancestor relationship with any of"
+            echo "  your original commits. Keeping the branch at one commit"
+            echo "  makes the squash result predictable and reviewable."
+            echo ""
+            echo "  Squash your branch into one commit before pushing:"
+            echo "    git reset --soft \$(git merge-base HEAD $base_ref)"
+            echo "    git commit -m 'type(scope): description'"
+            echo "    git push --force-with-lease"
+            exit 1
+          fi
+
+          echo "✓ PR has exactly 1 commit."
+
+      - name: Validate commit messages
+        run: |
+          base_ref="${{ github.event.pull_request.base.sha }}"
+          checker="scripts/check_commit_msg.py"
+
+          bad=0
+          count=0
+          tmp="$(mktemp)"
+          while IFS= read -r sha; do
+            count=$((count + 1))
+            # Feed the full message so the checker sees the subject line.
+            git log --format=%B --no-merges "$sha" -1 > "$tmp"
+            if ! python3 "$checker" "$tmp"; then
+              echo "  ↳ commit ${sha:0:9}"
+              bad=$((bad + 1))
+            fi
+          done < <(git log --format=%H --no-merges "$base_ref..HEAD")
+          rm -f "$tmp"
+
+          if [ "$bad" -ne 0 ]; then
+            echo ""
+            echo "✗ $bad of $count commit message(s) failed the style check."
+            echo "  See CONTRIBUTING.md → Commit messages for the rules."
+            exit 1
+          fi
+
+          echo "✓ All $count commit messages pass the style check."
+
+      - name: Validate commit body line length
+        run: |
+          base_ref="${{ github.event.pull_request.base.sha }}"
+          max_len=72
+          bad=""
+
+          while IFS= read -r hash; do
+            while IFS=: read -r lineno line; do
+              stripped="${line# }"  # strip leading ' ' that git log indents
+              if [ "${#stripped}" -gt "$max_len" ]; then
+                bad="${bad}\\n  ${hash:0:7} L${lineno}: ${stripped:0:80}..."
+              fi
+            done < <(
+              git log --format=%B --no-merges "$hash" -1 \
+                | awk 'NR>1 && length>'"$max_len"' && !/^[-*]/ && !/^  / {print NR": "$0}'
+            )
+          done < <(git log --format=%H --no-merges "$base_ref..HEAD")
+
+          if [ -n "$bad" ]; then
+            echo "✗ Commit body lines exceed $max_len characters:"
+            echo -e "$bad"
+            echo ""
+            echo "  Prose lines should wrap at $max_len chars."
+            echo "  Run: git commit --amend  (the commit-msg hook rewraps automatically)"
+            exit 1
+          fi
+
+          echo "✓ All commit body lines are ≤ $max_len characters."

--- a/scripts/check_commit_msg.py
+++ b/scripts/check_commit_msg.py
@@ -1,0 +1,239 @@
+#!/usr/bin/env python3
+"""Validate commit message format and style.
+
+Enforces Conventional Commits structure plus a subset of the Google
+CL-description style guidance that can be checked mechanically:
+
+- ``type(scope): description`` structure with an allowed type
+- description written in the imperative mood ("add", not "added"/"adds")
+- description starts lowercase and has no trailing period
+- subject length within a sane limit
+- description is not a vague placeholder ("fix bug", "wip", "update")
+
+Subjective guidance (body explains what + why, mentions shortcomings, etc.)
+lives in CONTRIBUTING.md and is not enforced here.
+"""
+
+from __future__ import annotations
+
+import re
+import sys
+from pathlib import Path
+
+ALLOWED_TYPES = (
+    "feat",
+    "fix",
+    "docs",
+    "style",
+    "refactor",
+    "perf",
+    "test",
+    "chore",
+    "build",
+    "ci",
+    "revert",
+)
+
+# type(scope)!: description  — scope and '!' optional. Description captured.
+CONVENTIONAL_RE = re.compile(
+    r"^(?P<type>" + "|".join(ALLOWED_TYPES) + r")"
+    r"(?P<scope>\([a-z0-9_,./-]+\))?"
+    r"(?P<breaking>!)?"
+    r": (?P<desc>.+)$"
+)
+
+# Soft/hard limits for the whole subject line.
+SUBJECT_SOFT_LIMIT = 50
+SUBJECT_HARD_LIMIT = 72
+
+# Common non-imperative first words: past tense, gerunds, and 3rd-person
+# singular. The imperative form is the bare verb ("add", "fix", "remove").
+NON_IMPERATIVE = {
+    # past tense / participles
+    "added": "add",
+    "created": "create",
+    "removed": "remove",
+    "deleted": "delete",
+    "fixed": "fix",
+    "changed": "change",
+    "updated": "update",
+    "renamed": "rename",
+    "moved": "move",
+    "refactored": "refactor",
+    "implemented": "implement",
+    "introduced": "introduce",
+    "improved": "improve",
+    "bumped": "bump",
+    "wired": "wire",
+    "dropped": "drop",
+    "merged": "merge",
+    "reverted": "revert",
+    "supported": "support",
+    "enabled": "enable",
+    "disabled": "disable",
+    # gerunds
+    "adding": "add",
+    "creating": "create",
+    "removing": "remove",
+    "deleting": "delete",
+    "fixing": "fix",
+    "changing": "change",
+    "updating": "update",
+    "renaming": "rename",
+    "moving": "move",
+    "refactoring": "refactor",
+    "implementing": "implement",
+    "introducing": "introduce",
+    "improving": "improve",
+    "bumping": "bump",
+    "wiring": "wire",
+    "dropping": "drop",
+    "merging": "merge",
+    "reverting": "revert",
+    "supporting": "support",
+    "enabling": "enable",
+    "disabling": "disable",
+    # 3rd-person singular
+    "adds": "add",
+    "creates": "create",
+    "removes": "remove",
+    "deletes": "delete",
+    "fixes": "fix",
+    "changes": "change",
+    "updates": "update",
+    "renames": "rename",
+    "moves": "move",
+    "implements": "implement",
+    "improves": "improve",
+}
+
+# Vague, low-information descriptions the Google guide calls out ("Fix bug",
+# "Add patch", "Phase 1", …). Matched case-insensitively against the whole
+# description, after normalising whitespace.
+VAGUE_DESCRIPTIONS = {
+    "fix bug",
+    "fix bugs",
+    "fix build",
+    "fix it",
+    "fix test",
+    "fix tests",
+    "fix stuff",
+    "add patch",
+    "add code",
+    "add stuff",
+    "add convenience functions",
+    "update",
+    "updates",
+    "update code",
+    "changes",
+    "change code",
+    "stuff",
+    "wip",
+    "misc",
+    "cleanup",
+    "minor changes",
+    "small fixes",
+}
+
+
+def read_message(path: Path) -> str:
+    text = path.read_text(encoding="utf-8")
+    return text.splitlines()[0].strip() if text else ""
+
+
+def is_exempt(subject: str) -> bool:
+    if not subject:
+        return False
+    if subject.startswith("Merge "):
+        return True
+    if subject.startswith("fixup!") or subject.startswith("squash!"):
+        return True
+    if subject.startswith("Revert "):
+        return True
+    return False
+
+
+def check_description(desc: str, errors: list[str]) -> None:
+    """Apply Google-style content checks to the description segment."""
+    normalized = re.sub(r"\s+", " ", desc.strip()).lower()
+
+    # Vague / placeholder descriptions.
+    if normalized in VAGUE_DESCRIPTIONS:
+        errors.append(
+            f"description {desc.strip()!r} is too vague — say specifically what "
+            "changed (e.g. 'add rel_ops pattern combinator', not 'update')"
+        )
+
+    # Trailing period on the subject.
+    if desc.rstrip().endswith("."):
+        errors.append("description must not end with a period")
+
+    # Capitalization: description should start lowercase (the type is the
+    # sentence opener in conventional commits). Allow acronyms / identifiers
+    # that are all-caps or contain internal capitals (e.g. 'DSL', 'API').
+    first = desc.strip().split(" ", 1)[0]
+    if first[:1].isupper() and not (first.isupper() or any(c.isupper() for c in first[1:])):
+        errors.append(
+            f"description should start lowercase ('{first.lower()}', not '{first}')"
+        )
+
+    # Imperative mood: reject past tense / gerund / 3rd-person first words.
+    first_word = re.sub(r"[^a-zA-Z]", "", first).lower()
+    if first_word in NON_IMPERATIVE:
+        errors.append(
+            f"use the imperative mood: '{NON_IMPERATIVE[first_word]}', "
+            f"not '{first_word}' (write the subject as an order)"
+        )
+
+
+def main() -> int:
+    if len(sys.argv) != 2:
+        print("usage: check_commit_msg.py <commit-msg-file>", file=sys.stderr)
+        return 2
+
+    subject = read_message(Path(sys.argv[1]))
+    if is_exempt(subject):
+        return 0
+
+    errors: list[str] = []
+    match = CONVENTIONAL_RE.match(subject)
+    if not match:
+        errors.append(
+            "subject must use conventional commits: "
+            "type(scope): description "
+            f"(types: {', '.join(ALLOWED_TYPES)})"
+        )
+    else:
+        desc = match.group("desc")
+        if len(desc) < 4:
+            errors.append("description must be at least four characters")
+        else:
+            check_description(desc, errors)
+
+    # Subject length is advisory, not a hard failure: squash-merge appends
+    # " (#NN)" which inflates the final subject, and the repo has a long
+    # history of informative >50-char subjects. Warn but do not block.
+    if len(subject) > SUBJECT_HARD_LIMIT:
+        print(
+            f"Commit message warning: subject is {len(subject)} chars; "
+            f"aim for ≤ {SUBJECT_SOFT_LIMIT}, keep under {SUBJECT_HARD_LIMIT} "
+            "where practical.",
+            file=sys.stderr,
+        )
+
+    if errors:
+        print("Commit message check failed:", file=sys.stderr)
+        print(f"  subject: {subject!r}", file=sys.stderr)
+        for error in errors:
+            print(f"  - {error}", file=sys.stderr)
+        print(
+            "\nExample: feat(patterns): add rel_ops pattern combinator",
+            file=sys.stderr,
+        )
+        return 1
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
**Summary**

Add the kinglet-style commit-style validation to patternia: a Validate PR workflow that enforces conventional-commit PR titles, a structured PR body, exactly one commit per PR, imperative commit subjects, and 72-character commit body lines. Also switch the PR template to the bold-section format the validator expects.

**Changes**

- Add `.github/workflows/validate.yml` with a `commit-style` job: PR title regex, PR body `**Summary**/**Changes**/**Testing**` section check (50-char minimum), single-commit rule, per-commit message style check, and commit body line length check (≤72 chars)
- Add `scripts/check_commit_msg.py` (adapted from kinglet bootstrap, kinglet-specific phase/ADR rules removed): validates conventional-commit structure, imperative mood, lowercase start, no trailing period, no vague descriptions
- Replace the four-section `##` PR template with the `**Summary**/**Changes**/**Testing**` format the validator greps for

**Testing**

Verified `scripts/check_commit_msg.py` locally against valid messages (`ci: add PR validation workflow`, `feat(patterns): add neg combinator` pass) and invalid ones (vague, non-imperative, capitalized, trailing period, missing type all fail). This PR's own branch commit passes the checker and the 72-character body rule.
