### PR TITLE
fix(ci): repair Windows matrix on the vs2026 runner image

### DIFF
--- a/.github/workflows/ci-full.yml
+++ b/.github/workflows/ci-full.yml
@@ -68,13 +68,17 @@ jobs:
             std: 26
 
           # ===== Windows: clang-cl =====
-          - os: windows-latest
+          # Pinned to windows-2022: the windows-2025-vs2026 image bundles
+          # Clang 22, which cmake < 4.2 cannot configure ("no known features
+          # for CXX compiler Clang"). windows-2022 pairs VS2022 with a
+          # cmake that still understands its clang-cl.
+          - os: windows-2022
             compiler: clang-cl
             std: 20
-          - os: windows-latest
+          - os: windows-2022
             compiler: clang-cl
             std: 23
-          - os: windows-latest
+          - os: windows-2022
             compiler: clang-cl
             std: 26
 
@@ -102,14 +106,22 @@ jobs:
       - name: Configure CMake (Windows)
         if: runner.os == 'Windows'
         run: |
+          # windows-latest moved to windows-2025-vs2026, which ships only
+          # Visual Studio 2026 (generator "Visual Studio 18 2026"); the old
+          # VS 17 2022 instance no longer exists on the image.
+          $generator = if (& cmake --version | Select-String "4\.") {
+            "Visual Studio 18 2026"
+          } else {
+            "Visual Studio 17 2022"
+          }
           if ("${{ matrix.compiler }}" -eq "msvc") {
-            cmake -S . -B build -G "Visual Studio 17 2022" -A x64 `
+            cmake -S . -B build -G "$generator" -A x64 `
               -DCMAKE_CXX_STANDARD=${{ matrix.std }} `
               -DPTN_BUILD_TESTS=ON `
               -DPTN_BUILD_BENCHMARKS=OFF `
               -DPTN_SKIP_COMPILER_CHECK=ON
           } else {
-            cmake -S . -B build -G "Visual Studio 17 2022" -A x64 -T ClangCL `
+            cmake -S . -B build -G "$generator" -A x64 -T ClangCL `
               -DCMAKE_CXX_STANDARD=${{ matrix.std }} `
               -DPTN_BUILD_TESTS=ON `
               -DPTN_BUILD_BENCHMARKS=OFF `


### PR DESCRIPTION
**Summary**

Fix the Windows matrix jobs in CI (Full Matrix), which have all been failing since the windows-latest runner image moved to windows-2025-vs2026. The new image ships only Visual Studio 2026, so configuring with the hardcoded "Visual Studio 17 2022" generator fails with "could not find any instance of Visual Studio". It also bundles Clang 22, which cmake before 4.2 has no compile-feature metadata for, breaking every target_compile_features call on the clang-cl leg.

**Changes**

- In the Windows configure step of ci-full.yml, select the VS generator at runtime: "Visual Studio 18 2026" when the runner ships cmake 4.x (the first version with that generator), otherwise keep "Visual Studio 17 2022" so older runner images keep working
- Pin the clang-cl matrix legs to windows-2022: the vs2026 image's Clang 22 defeats cmake's feature detection on both the VS ClangCL toolset and the stock LLVM clang fallback (tried Ninja plus explicit clang/clang++ paths; cmake still probes cl-style), while windows-2022 pairs VS2022 with a cmake that understands its clang-cl
- No Linux/macOS changes

**Testing**

Cannot be exercised locally (no Windows toolchain on the dev box); verified through this PR's CI runs. The generator fix made all three msvc legs pass on windows-latest. The clang-cl legs failed with "no known features for CXX compiler Clang version 22.1.3" under both the VS ClangCL toolset and the Ninja/LLVM-clang fallback, and now pass on windows-2022 across C++20/23/26.