### PR TITLE
feat(dsl): add PTN_BIND macro for named guard placeholders

### DIFF
--- a/include/ptn/patternia.hpp
+++ b/include/ptn/patternia.hpp
@@ -170,4 +170,82 @@ namespace ptn {
 #define PTN_LET(name, ...) PTN_WHERE((name), __VA_ARGS__)
 #endif
 
+// PTN_BIND(Type, member0, member1, ...)
+//
+// Declares named placeholder objects for use in guard expressions.
+// Each name is an inline constexpr arg_t<N> where N is the
+// zero-based position of the member in the argument list. These
+// placeholders integrate directly with the existing
+// expression-template machinery (operators, eval, max_arg_index) and
+// replace positional placeholders
+// (_0, arg<1>, etc.) with readable identifiers.
+//
+// Example:
+//   struct Point { int x; int y; };
+//   PTN_BIND(Point, x, y);
+//
+//   match(p) | PTN_ON(
+//       $(has<&Point::x, &Point::y>)[x*x + y*y == 25]
+//           >> [](auto& p) { return dist(p); }
+//   );
+//
+// NOTE: The Type argument is currently unused by the generated code.
+// It serves as documentation: the names are expected to correspond
+// to the members of Type, listed in the same order as in has<...>.
+// A future reflection-based variant may validate this at compile
+// time.
+//
+// Supports 1 to 5 member names.
+#define PTN_BIND_1(Type, m0)                                        \
+  inline constexpr ::ptn::pat::mod::arg_t<0> m0 {                   \
+  }
+
+#define PTN_BIND_2(Type, m0, m1)                                    \
+  inline constexpr ::ptn::pat::mod::arg_t<0> m0{};                  \
+  inline constexpr ::ptn::pat::mod::arg_t<1> m1 {                   \
+  }
+
+#define PTN_BIND_3(Type, m0, m1, m2)                                \
+  inline constexpr ::ptn::pat::mod::arg_t<0> m0{};                  \
+  inline constexpr ::ptn::pat::mod::arg_t<1> m1{};                  \
+  inline constexpr ::ptn::pat::mod::arg_t<2> m2 {                   \
+  }
+
+#define PTN_BIND_4(Type, m0, m1, m2, m3)                            \
+  inline constexpr ::ptn::pat::mod::arg_t<0> m0{};                  \
+  inline constexpr ::ptn::pat::mod::arg_t<1> m1{};                  \
+  inline constexpr ::ptn::pat::mod::arg_t<2> m2{};                  \
+  inline constexpr ::ptn::pat::mod::arg_t<3> m3 {                   \
+  }
+
+#define PTN_BIND_5(Type, m0, m1, m2, m3, m4)                        \
+  inline constexpr ::ptn::pat::mod::arg_t<0> m0{};                  \
+  inline constexpr ::ptn::pat::mod::arg_t<1> m1{};                  \
+  inline constexpr ::ptn::pat::mod::arg_t<2> m2{};                  \
+  inline constexpr ::ptn::pat::mod::arg_t<3> m3{};                  \
+  inline constexpr ::ptn::pat::mod::arg_t<4> m4 {                   \
+  }
+
+#define PTN_BIND_PICK(_1, _2, _3, _4, _5, NAME, ...) NAME
+
+// Extra indirection layers for MSVC traditional preprocessor
+// compatibility. Without these, MSVC treats __VA_ARGS__ as a single
+// token when forwarding between macros, breaking the count dispatch
+// and the final macro invocation.
+#define PTN_BIND_EXPAND(...) __VA_ARGS__
+#define PTN_BIND_DISPATCH(Macro, Type, ...)                         \
+  PTN_BIND_EXPAND(Macro(Type, __VA_ARGS__))
+
+#ifndef PTN_BIND
+#define PTN_BIND(Type, ...)                                         \
+  PTN_BIND_DISPATCH(PTN_BIND_EXPAND(PTN_BIND_PICK(__VA_ARGS__,      \
+                                                  PTN_BIND_5,       \
+                                                  PTN_BIND_4,       \
+                                                  PTN_BIND_3,       \
+                                                  PTN_BIND_2,       \
+                                                  PTN_BIND_1)),     \
+                    Type,                                           \
+                    __VA_ARGS__)
+#endif
+
 // IWYU pragma: end_exports

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -25,6 +25,7 @@ add_executable(ptn_tests
   tests_public_api.cpp
   tests_terminal_semantics.cpp
   tests_type_pattern.cpp
+  tests_named_placeholder.cpp
 )
 
 target_link_libraries(ptn_tests PRIVATE

--- a/tests/tests_named_placeholder.cpp
+++ b/tests/tests_named_placeholder.cpp
@@ -1,0 +1,226 @@
+// Tests for PTN_BIND named placeholder macro.
+//
+// Verifies that named placeholders declared via PTN_BIND produce the
+// same types and runtime results as the positional placeholders (_0,
+// arg<N>) they replace. All tests exercise the full match pipeline
+// (match | on($[guard] >> handler)) to ensure end-to-end
+// correctness.
+
+#include <gtest/gtest.h>
+
+#include "ptn/patternia.hpp"
+
+// Test fixture structs.
+namespace {
+
+  struct Point {
+    int x;
+    int y;
+  };
+
+  struct Packet {
+    int type;
+    int len;
+  };
+
+  struct Triple {
+    int a;
+    int b;
+    int c;
+  };
+
+  // Declare named placeholders for each struct.
+  // These are namespace-scoped inline constexpr arg_t<N> objects.
+  PTN_BIND(Point, x, y);
+  PTN_BIND(Packet, type, len);
+  PTN_BIND(Triple, a, b, c);
+
+} // namespace
+
+// =========================================================================
+// Type correctness: PTN_BIND names must be arg_t<N> of the right
+// index.
+// =========================================================================
+
+TEST(NamedPlaceholder, SingleArgTypeMatchesArg0) {
+  static_assert(std::is_same_v<std::decay_t<decltype(x)>,
+                               ptn::pat::mod::arg_t<0>>);
+}
+
+TEST(NamedPlaceholder, TwoArgTypesMatchPositions) {
+  static_assert(std::is_same_v<std::decay_t<decltype(x)>,
+                               ptn::pat::mod::arg_t<0>>);
+  static_assert(std::is_same_v<std::decay_t<decltype(y)>,
+                               ptn::pat::mod::arg_t<1>>);
+}
+
+TEST(NamedPlaceholder, ThreeArgTypesMatchPositions) {
+  static_assert(std::is_same_v<std::decay_t<decltype(a)>,
+                               ptn::pat::mod::arg_t<0>>);
+  static_assert(std::is_same_v<std::decay_t<decltype(b)>,
+                               ptn::pat::mod::arg_t<1>>);
+  static_assert(std::is_same_v<std::decay_t<decltype(c)>,
+                               ptn::pat::mod::arg_t<2>>);
+}
+
+// =========================================================================
+// Runtime correctness: named placeholders in guard expressions.
+// =========================================================================
+
+TEST(NamedPlaceholder, SingleValueGuard) {
+  // Same as: $[_0 > 5]
+  // Now:    $[x > 5]  (where x maps to arg<0>)
+  int  val    = 10;
+  auto result = ptn::match(val)
+                | PTN_ON(
+                    ptn::$[x > 5] >> [](int v) { return v * 2; },
+                    ptn::_ >> 0);
+  EXPECT_EQ(result, 20);
+}
+
+TEST(NamedPlaceholder, SingleValueGuardFails) {
+  int  val    = 3;
+  auto result = ptn::match(val)
+                | PTN_ON(
+                    ptn::$[x > 5] >> [](int v) { return v * 2; },
+                    ptn::_ >> 0);
+  EXPECT_EQ(result, 0);
+}
+
+TEST(NamedPlaceholder, StructuralGuardTwoMembers) {
+  // Same as:
+  //   $(has<&Point::x, &Point::y>)[_0*_0 + arg<1>*arg<1> == 25]
+  // Now:
+  //   $(has<&Point::x, &Point::y>)[x*x + y*y == 25]
+  Point p{3, 4};
+  auto  result = ptn::match(p)
+                | PTN_ON(
+                    ptn::$(ptn::has<&Point::x,
+                                    &Point::y>)[x * x + y * y == 25]
+                        >> 1,
+                    ptn::_ >> 0);
+  EXPECT_EQ(result, 1);
+}
+
+TEST(NamedPlaceholder, StructuralGuardFails) {
+  Point p{1, 1};
+  auto  result = ptn::match(p)
+                | PTN_ON(
+                    ptn::$(ptn::has<&Point::x,
+                                    &Point::y>)[x * x + y * y == 25]
+                        >> 1,
+                    ptn::_ >> 0);
+  EXPECT_EQ(result, 0);
+}
+
+TEST(NamedPlaceholder, StructuralGuardLessThan) {
+  // x < y
+  Point p{3, 7};
+  auto  result = ptn::match(p)
+                | PTN_ON(
+                    ptn::$(ptn::has<&Point::x, &Point::y>)[x < y]
+                        >> 1,
+                    ptn::_ >> 0);
+  EXPECT_EQ(result, 1);
+}
+
+TEST(NamedPlaceholder, StructuralGuardEquality) {
+  // type == 0x01
+  Packet pkt{0x01, 42};
+  auto   result = ptn::match(pkt)
+                | PTN_ON(
+                    ptn::$(ptn::has<&Packet::type>)[type == 1] >> 1,
+                    ptn::_ >> 0);
+  EXPECT_EQ(result, 1);
+}
+
+TEST(NamedPlaceholder, StructuralGuardCompound) {
+  // type == 0x01 && len > 0
+  Packet pkt{0x01, 42};
+  auto   result = ptn::match(pkt)
+                | PTN_ON(
+                    ptn::$(
+                        ptn::has<&Packet::type,
+                                 &Packet::len>)[type == 1 && len > 0]
+                        >> 1,
+                    ptn::_ >> 0);
+  EXPECT_EQ(result, 1);
+}
+
+TEST(NamedPlaceholder, ThreeMemberGuard) {
+  // a + b == c
+  Triple t{2, 3, 5};
+  auto   result = ptn::match(t)
+                | PTN_ON(ptn::$(ptn::has<&Triple::a,
+                                         &Triple::b,
+                                         &Triple::c>)[a + b == c]
+                             >> 1,
+                         ptn::_ >> 0);
+  EXPECT_EQ(result, 1);
+}
+
+TEST(NamedPlaceholder, ThreeMemberGuardFails) {
+  Triple t{2, 3, 6};
+  auto   result = ptn::match(t)
+                | PTN_ON(ptn::$(ptn::has<&Triple::a,
+                                         &Triple::b,
+                                         &Triple::c>)[a + b == c]
+                             >> 1,
+                         ptn::_ >> 0);
+  EXPECT_EQ(result, 0);
+}
+
+// =========================================================================
+// Equivalence: named and positional placeholders produce identical
+// results for the same expression.
+// =========================================================================
+
+TEST(NamedPlaceholder, NamedEquivalentToPositional) {
+  using ptn::_0;
+  using ptn::arg;
+
+  Point p{3, 4};
+
+  auto named = ptn::match(p)
+               | PTN_ON(
+                   ptn::$(ptn::has<&Point::x,
+                                   &Point::y>)[x * x + y * y == 25]
+                       >> 1,
+                   ptn::_ >> 0);
+
+  auto positional = ptn::match(p)
+                    | PTN_ON(
+                        ptn::$(ptn::has<&Point::x, &Point::y>)
+                                [_0 * _0 + arg<1> * arg<1> == 25]
+                            >> 1,
+                        ptn::_ >> 0);
+
+  EXPECT_EQ(named, positional);
+  EXPECT_EQ(named, 1);
+}
+
+// =========================================================================
+// Arithmetic expressions in guards (not just comparisons).
+// =========================================================================
+
+TEST(NamedPlaceholder, ArithmeticThenCompare) {
+  // x + y > 5
+  Point p{3, 4};
+  auto  result = ptn::match(p)
+                | PTN_ON(
+                    ptn::$(ptn::has<&Point::x, &Point::y>)[x + y > 5]
+                        >> 1,
+                    ptn::_ >> 0);
+  EXPECT_EQ(result, 1);
+}
+
+TEST(NamedPlaceholder, MixedArithmeticAndComparison) {
+  // x*x + y*y < 50 && x < y
+  Point p{3, 4};
+  auto  result = ptn::match(p)
+                | PTN_ON(ptn::$(ptn::has<&Point::x, &Point::y>)
+                                 [x * x + y * y < 50 && x < y]
+                             >> 1,
+                         ptn::_ >> 0);
+  EXPECT_EQ(result, 1);
+}


### PR DESCRIPTION
**Summary**

Introduces `PTN_BIND(Type, m0, m1, ...)` — a macro that declares named placeholder objects for use in guard expressions, replacing positional placeholders (`_0`, `arg<1>`) with readable identifiers.

Before:
```cpp
$(has<&Point::x, &Point::y>)[_0*_0 + arg<1>*arg<1> == 25]
```

After:
```cpp
PTN_BIND(Point, x, y);
$(has<&Point::x, &Point::y>)[x*x + y*y == 25]
```

**Changes**

- Add `PTN_BIND` macro and its `_1`–`_5` size variants to `patternia.hpp`
- Generated objects are `inline constexpr arg_t<N>` — identical types to `_0`/`arg<N>`, so all existing expression-template machinery (operators, `eval`, `max_arg_index`) works unchanged
- Supports 1 to 5 member names (matching `PTN_WHERE` coverage)
- Add 15 new tests in `tests_named_placeholder.cpp`
- Register new test file in `tests/CMakeLists.txt`
- Purely additive: existing `_0`, `arg<N>`, `PTN_WHERE`, `PTN_LET` remain unchanged

**Testing**

- All 151 tests pass (136 existing + 15 new), zero regressions
- New tests cover: type correctness for each position, single/two/three-member structural guards, arithmetic + comparison compound expressions, and direct equivalence with positional placeholders
- clang-format clean on all changed files
- Commit message passes `scripts/check_commit_msg.py` validation