### PR TITLE
ci: switch to LLVM source-based coverage & expand benchmark scenarios

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -56,14 +56,21 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Install lcov
-        run: sudo apt-get install -y lcov
+      - name: Install LLVM tools
+        run: |
+          wget -qO- https://apt.llvm.org/llvm-snapshot.gpg.key | sudo apt-key add -
+          sudo add-apt-repository -y 'deb http://apt.llvm.org/jammy/ llvm-toolchain-jammy-18 main'
+          sudo apt-get update -qq
+          sudo apt-get install -y -qq llvm-18 clang-18
 
-      - name: Configure
+      - name: Configure (Clang + source-based coverage)
         run: |
           cmake -S . -B build \
             -DCMAKE_BUILD_TYPE=Debug \
-            -DCMAKE_CXX_FLAGS="--coverage" \
+            -DCMAKE_C_COMPILER=clang-18 \
+            -DCMAKE_CXX_COMPILER=clang++-18 \
+            -DCMAKE_CXX_FLAGS="-fprofile-instr-generate -fcoverage-mapping -O0" \
+            -DCMAKE_EXE_LINKER_FLAGS="-fprofile-instr-generate" \
             -DPTN_BUILD_TESTS=ON \
             -DPTN_BUILD_BENCHMARKS=OFF \
             -DPTN_SKIP_COMPILER_CHECK=ON
@@ -76,9 +83,27 @@ jobs:
 
       - name: Capture coverage
         run: |
-          lcov --capture --directory build --output-file coverage.info --ignore-errors mismatch
-          lcov --remove coverage.info '/usr/*' '*/_deps/*' '*/tests/*' --output-file coverage.info
-          lcov --list coverage.info
+          # Merge raw profiles from all test runs.
+          find build -name '*.profraw' > profraw_list.txt
+          llvm-profdata-18 merge \
+            -input-files profraw_list.txt \
+            -output coverage.profdata \
+            -sparse
+
+          # Export lcov-format text for Codecov.
+          llvm-cov-18 export \
+            -format=lcov \
+            -instr-profile=coverage.profdata \
+            -ignore-filename-regex='(_deps|/usr/|tests/)' \
+            build/tests/ptn_tests \
+            > coverage.info
+
+          # Summary for the CI log.
+          llvm-cov-18 report \
+            -instr-profile=coverage.profdata \
+            -use-color \
+            -ignore-filename-regex='(_deps|/usr/|tests/)' \
+            build/tests/ptn_tests
 
       - name: Upload to Codecov
         uses: codecov/codecov-action@v5
@@ -113,7 +138,7 @@ jobs:
         run: |
           mkdir -p bench_results
           build/bench/ptn_bench \
-            --benchmark_filter="(PatterniaPipe|StdVisit)_VariantMixed/|(PatterniaPipe|IfElse)_ProtocolRouter/|(PatterniaPipe|Switch)_CommandParser/|(PatterniaPipe|Switch)_PacketMixed/" \
+            --benchmark_filter="VariantMixed$|VariantAltHot$|VariantMixedGuarded$|VariantAltHotGuarded$|ProtocolRouter$|CommandParser$|PacketMixed$|PacketMixedHeavyBind$|LiteralMatch$|LiteralMatchRDense$" \
             --benchmark_format=json \
             > bench_results/ptn_bench.json
 
@@ -135,7 +160,7 @@ jobs:
         run: |
           python scripts/bench_single_report.py \
             --input bench_results/ptn_bench.json \
-            --include "(PatterniaPipe|StdVisit)_VariantMixed/|(PatterniaPipe|IfElse)_ProtocolRouter/|(PatterniaPipe|Switch)_CommandParser/|(PatterniaPipe|Switch)_PacketMixed/" \
+            --include "VariantMixed$|VariantAltHot$|VariantMixedGuarded$|VariantAltHotGuarded$|ProtocolRouter$|CommandParser$|PacketMixed$|PacketMixedHeavyBind$|LiteralMatch$|LiteralMatchRDense$" \
             --outdir docs/assets/bench \
             --prefix latest \
             --title "Patternia vs Standard C++"

--- a/.github/workflows/clang-format-check.yml
+++ b/.github/workflows/clang-format-check.yml
@@ -3,30 +3,8 @@ name: clang-format Check
 on:
   pull_request:
     branches: [main]
-    paths:
-      - "**/*.h"
-      - "**/*.hpp"
-      - "**/*.hh"
-      - "**/*.hxx"
-      - "**/*.c"
-      - "**/*.cc"
-      - "**/*.cpp"
-      - "**/*.cxx"
-      - "**/*.ipp"
-      - ".clang-format"
   push:
     branches: [main]
-    paths:
-      - "**/*.h"
-      - "**/*.hpp"
-      - "**/*.hh"
-      - "**/*.hxx"
-      - "**/*.c"
-      - "**/*.cc"
-      - "**/*.cpp"
-      - "**/*.cxx"
-      - "**/*.ipp"
-      - ".clang-format"
 
 permissions:
   contents: read

--- a/scripts/bench_single_report.py
+++ b/scripts/bench_single_report.py
@@ -475,11 +475,15 @@ def _plot(
         max_ratio = max(max_ratio, *(p.mean_ns / fastest for p in nested[scenario].values()))
 
     x_max = max(1.35, max_ratio * 1.14)
-    fig_h = max(6.0, len(scenarios) * 0.68 + 2.7)
+    n = len(scenarios)
+    fig_h = max(6.0, n * 0.72 + 3.2)
     fig, ax = plt.subplots(figsize=(14.2, fig_h), dpi=220)
     fig.patch.set_facecolor("#f4f1ea")
     ax.set_facecolor("#fffdf8")
-    ax.set_position([0.14, 0.26, 0.80, 0.46])
+    # Dynamically size the axes area to the figure height.
+    ax_bottom = 0.26
+    ax_height = min(0.64, max(0.40, n * 0.052))
+    ax.set_position([0.14, ax_bottom, 0.80, ax_height])
 
     # Reading bands turn relative performance into a quick visual filter.
     ax.axvspan(1.0, min(1.05, x_max), color="#dcfce7", alpha=0.75, zorder=0)
@@ -581,8 +585,9 @@ def _plot(
         )
 
     labels = [_label(s) for s in scenarios]
+    label_size = 11.5 if len(scenarios) <= 6 else 10.0
     ax.set_yticks(list(range(len(scenarios))))
-    ax.set_yticklabels(labels, fontsize=11.5, color="#0f172a")
+    ax.set_yticklabels(labels, fontsize=label_size, color="#0f172a")
     ax.invert_yaxis()
     ax.set_ylim(len(scenarios) - 0.25, -0.55)
     ax.set_xlim(0.97, x_max)


### PR DESCRIPTION
**Summary**

Switch CI coverage from gcc gcov to LLVM source-based coverage, and expand benchmark scenario coverage from 4 to 10 scenarios.

**Changes**

- Coverage: `--coverage` (gcc gcov) -> `-fprofile-instr-generate -fcoverage-mapping` (Clang 18 source-based), using `llvm-profdata-18 merge` + `llvm-cov-18 export` instead of lcov. IIFE/macro expansions are now correctly attributed.
- Benchmark filter: 4 -> 10 scenarios, adding `VariantAltHot`, `VariantMixedGuarded`, `VariantAltHotGuarded`, `PacketMixedHeavyBind`, `LiteralMatch`, `LiteralMatchRDense`.
- Chart adaptation: figure height and axes area dynamically scale with scenario count; y-axis label font shrinks for >6 scenarios to prevent overlap.

**Testing**

CI fully passing: coverage job (clang-18 LLVM source-based) pass, build-and-test pass, full matrix compilation pass. Benchmark job conditionally runs only on merge to main (`if: github.event_name == 'push' && github.ref == 'refs/heads/main'`).
