### PR TITLE
ci: run ci.yml on docs-only pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,12 +11,10 @@ on:
       - ".github/ISSUE_TEMPLATE/**"
   pull_request:
     branches: [main]
-    paths-ignore:
-      - "README.md"
-      - "CONTRIBUTING.md"
-      - "docs/**"
-      - "LICENSE"
-      - ".github/ISSUE_TEMPLATE/**"
+    # NOTE: no paths-ignore here on purpose. Branch protection
+    # requires the build-and-test/coverage checks from this
+    # workflow; skipping docs-only PRs would leave those checks
+    # unreported and block the merge (see PR #45).
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}


### PR DESCRIPTION
**Summary**

Fix the structural deadlock that blocked docs-only PRs: branch protection requires the `build-and-test`/`coverage` checks from `ci.yml`, but the workflow's `pull_request` trigger ignored docs paths, so those required checks never reported and PRs like #45 needed an admin override to merge.

**Changes**

- Drop `paths-ignore` from the `pull_request` trigger in `.github/workflows/ci.yml`, so required checks always report on every PR.
- Keep `paths-ignore` on the `push` trigger — docs-only pushes to `main` still skip the full suite.
- Add an inline comment recording why the PR trigger must stay unfiltered, with a reference to PR #45.

**Testing**

- Workflow YAML parses cleanly (PyYAML).
- The change only affects when the workflow starts; no job logic is modified.
- Self-verifying: this PR touches `.github/`, so the full matrix including `build-and-test` and `coverage` must report green before merge. A follow-up docs-only PR can serve as the real-world confirmation.