### PR TITLE
feat(guard): anchor PTN_BIND names to members

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -205,14 +205,28 @@ explicit name.
 
 ### `PTN_BIND(Type, names...)`
 
-Declares readable placeholders for multi-binding guards. List the names in the
-same order as the members passed to `has<>`.
+Declares member-anchored placeholders for structural guards. Each name must
+designate a non-static data member of `Type`; the macro expands `name` to
+`constexpr member_t<&Type::name>`.
 
 ```cpp
 PTN_BIND(Point, x, y);
 
 $(has<&Point::x, &Point::y>)[x * x + y * y == 25]
 ```
+
+Inside a guard, names resolve to the position of their member in the `has<>`
+member list at compile time, so they follow members, not positions — the order
+of member pointers in `has<>` does not matter:
+
+```cpp
+$(has<&Point::y, &Point::x>)[x == 3 && y == 4]  // x is still .x
+```
+
+Misuse is caught at compile time: a misspelled member name fails right at the
+`PTN_BIND` line, and a name whose member is not listed in `has<>` fails a
+static_assert. Member names are only valid in guards attached to `has<...>`;
+using them on a non-structural pattern is a compile-time error.
 
 ### `rng(lo, hi, mode)`
 
@@ -226,6 +240,10 @@ $[rng(0, 10, pat::mod::open)]
 `PTN_BIND` supports one to ten names and can be declared at namespace or block
 scope. Use callables for domain logic that does not read naturally as `_` or a
 short named-placeholder expression.
+
+Note: block-scope names cannot be referenced inside `PTN_ON`, because its
+caching lambda cannot capture them. Use plain `on(...)` there, or declare the
+names at namespace scope.
 
 ### Migration from positional guard APIs
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -54,6 +54,23 @@ extensions cost one short macro per level. See PR #44.
 
 ---
 
+### Member-anchored `PTN_BIND` placeholders
+
+`PTN_BIND(Type, ...)` names expand to `member_t<&Type::name>`
+instead of positional `arg_t<N>`. Guards resolve each name to the
+position of its member in the `has<...>` member list at compile
+time:
+
+- names follow members, so `has<...>` order no longer matters;
+- misspelled member names fail at the `PTN_BIND` line;
+- a name used with a `has<...>` that lacks its member fails a
+  static_assert.
+
+This also settles the previously deferred `Type`-validation item
+without static reflection.
+
+---
+
 ## NEXT
 
 Potential follow-up items after current WIP scope is stabilized.
@@ -120,6 +137,6 @@ here so they are not re-proposed without new motivation.
 - **Chained comparisons** (`1 <= _ <= 10`): breaks predicate
   semantics and produces unreadable diagnostics. Use `rng(lo, hi)`
   with explicit range modes.
-- **`PTN_BIND` `Type` validation**: deferred. The `Type` argument is
-  documentary for now; member-name checking becomes feasible with
-  static reflection (C++26).
+- **`PTN_BIND` `Type` validation**: resolved without reflection —
+  names now expand to `member_t<&Type::name>`, so member checking
+  happens at declaration time (see WIP above).

--- a/include/ptn/pattern/base/binding_base.hpp
+++ b/include/ptn/pattern/base/binding_base.hpp
@@ -8,10 +8,25 @@
 
 #include "ptn/pattern/modifiers/fwd.h"
 #include <type_traits>
+#include <utility>
 
 namespace ptn::pat::base {
 
-  // CRTP mixin that provides guard operator (`[]`) for binding patterns.
+  // Hook that lets a binding pattern rewrite its guard predicate
+  // before the guarded pattern is built. The default is the
+  // identity; structural binding patterns specialize this to
+  // resolve PTN_BIND member placeholders against their member
+  // list.
+  template <typename Derived>
+  struct guard_resolver {
+    template <typename P>
+    static constexpr decltype(auto) apply(P &&pred) {
+      return std::forward<P>(pred);
+    }
+  };
+
+  // CRTP mixin that provides guard operator (`[]`) for binding
+  // patterns.
   //
   // This class enables the guard syntax `pattern[predicate]` by
   // providing the operator[] that creates a guarded_pattern.
@@ -30,19 +45,23 @@ namespace ptn::pat::base {
     //   Pred: The predicate type (typically a lambda or function).
     // Parameters:
     //   pred: The predicate function to apply to the bound value.
-    // Returns: A guarded_pattern that combines the pattern with the predicate.
+    // Returns: A guarded_pattern that combines the pattern with the
+    // predicate.
     template <typename Pred>
     auto operator[](Pred &&pred) const {
-      using D = std::decay_t<Derived>;
-      return mod::guarded_pattern<D, std::decay_t<Pred>>{
-          static_cast<const D &>(*this), std::forward<Pred>(pred)};
+      using D       = std::decay_t<Derived>;
+      auto resolved = guard_resolver<D>::apply(
+          std::forward<Pred>(pred));
+      return mod::guarded_pattern<D, decltype(resolved)>{
+          static_cast<const D &>(*this), std::move(resolved)};
     }
   };
 
   // Base class for patterns that can bind values.
   //
   // All binding patterns should inherit from this class to gain
-  // guard operator functionality and mark themselves as binding patterns.
+  // guard operator functionality and mark themselves as binding
+  // patterns.
   //
   // Template parameter:
   //   Derived: The derived pattern type (CRTP).

--- a/include/ptn/pattern/base/pattern_traits.hpp
+++ b/include/ptn/pattern/base/pattern_traits.hpp
@@ -2,9 +2,9 @@
 
 // Compile-time detection utilities for Patternia patterns.
 //
-// This file provides type traits for detecting and characterizing patterns,
-// including pattern identification, binding pattern detection, structural
-// pattern traits, and guard predicate traits.
+// This file provides type traits for detecting and characterizing
+// patterns, including pattern identification, binding pattern
+// detection, structural pattern traits, and guard predicate traits.
 
 #include <type_traits>
 #include <utility>
@@ -25,23 +25,24 @@ namespace ptn::pat::traits {
   template <typename P>
   struct has_match_method<
       P,
-      std::void_t<decltype(static_cast<bool>(std::declval<const P &>().match(
-          std::declval<int>())))>> : std::true_type {};
+      std::void_t<decltype(static_cast<bool>(
+          std::declval<const P &>().match(std::declval<int>())))>>
+      : std::true_type {};
 
   // Variable template for has_match_method<P>::value.
   template <typename P>
-  inline constexpr bool has_match_method_v = has_match_method<P>::value;
+  inline constexpr bool
+      has_match_method_v = has_match_method<P>::value;
 
   // Trait: determines whether P acts as a Pattern.
   //
-  // A type is considered a pattern if it inherits from base::pattern_tag
-  // OR has a .match(Subject) method.
+  // A type is considered a pattern if it inherits from
+  // base::pattern_tag OR has a .match(Subject) method.
   template <typename P>
-  struct is_pattern
-      : std::integral_constant<
-            bool,
-            std::is_base_of_v<base::pattern_tag, P> || has_match_method_v<P>> {
-  };
+  struct is_pattern : std::integral_constant<
+                          bool,
+                          std::is_base_of_v<base::pattern_tag, P>
+                              || has_match_method_v<P>> {};
 
   // Convenience variable template for is_pattern<P>::value.
   template <typename P>
@@ -53,8 +54,8 @@ namespace ptn::pat::traits {
 
   // Detects if a pattern is a binding pattern.
   //
-  // Binding patterns are those that inherit from binding_pattern_base and
-  // have a static is_binding member.
+  // Binding patterns are those that inherit from
+  // binding_pattern_base and have a static is_binding member.
   template <typename P, typename = void>
   struct is_binding_pattern : std::false_type {};
 
@@ -65,7 +66,8 @@ namespace ptn::pat::traits {
 
   // Helper variable template for is_binding_pattern.
   template <typename P>
-  inline constexpr bool is_binding_pattern_v = is_binding_pattern<P>::value;
+  inline constexpr bool
+      is_binding_pattern_v = is_binding_pattern<P>::value;
 
   // -----------------------------------------------------------------------
   // Structural-pattern traits.
@@ -73,21 +75,22 @@ namespace ptn::pat::traits {
 
   // Checks if M is a non-static data member pointer.
   template <auto M>
-  inline constexpr bool is_data_member_ptr_v =
-      std::is_member_object_pointer_v<decltype(M)>;
+  inline constexpr bool is_data_member_ptr_v = std::
+      is_member_object_pointer_v<decltype(M)>;
 
   // Checks if M is a nullptr placeholder (e.g., _ign).
   template <auto M>
-  inline constexpr bool is_nullptr_placeholder_v =
-      std::is_same_v<std::decay_t<decltype(M)>, std::nullptr_t>;
+  inline constexpr bool is_nullptr_placeholder_v = std::
+      is_same_v<std::decay_t<decltype(M)>, std::nullptr_t>;
 
   // Unified notion: M is a structural element.
   //
-  // Structural elements are either data member pointers or nullptr placeholders
-  // used in has<> patterns.
+  // Structural elements are either data member pointers or nullptr
+  // placeholders used in has<> patterns.
   template <auto M>
-  inline constexpr bool is_structural_element_v =
-      is_data_member_ptr_v<M> || is_nullptr_placeholder_v<M>;
+  inline constexpr bool
+      is_structural_element_v = is_data_member_ptr_v<M>
+                                || is_nullptr_placeholder_v<M>;
 
   // -----------------------------------------------------------------------
   // Guard-predicate traits.
@@ -95,7 +98,8 @@ namespace ptn::pat::traits {
 
   // Marker tag for guard predicates.
   //
-  // Guard predicates should inherit from this tag to enable detection.
+  // Guard predicates should inherit from this tag to enable
+  // detection.
   struct guard_predicate_tag {};
 
   // Detects if a type is a guard predicate.
@@ -103,18 +107,23 @@ namespace ptn::pat::traits {
   // A type is considered a guard predicate if it inherits from
   // guard_predicate_tag.
   template <typename T>
-  inline constexpr bool is_guard_predicate_v =
-      std::is_base_of_v<guard_predicate_tag, std::decay_t<T>>;
+  inline constexpr bool
+      is_guard_predicate_v = std::is_base_of_v<guard_predicate_tag,
+                                               std::decay_t<T>>;
 
   // Trait to detect argument expression nodes.
   //
-  // Argument expressions include placeholders (arg_t), value wrappers (val_t),
-  // binary expressions (bin_expr), and unary expressions (un_expr).
+  // Argument expressions include placeholders (arg_t), value
+  // wrappers (val_t), binary expressions (bin_expr), and unary
+  // expressions (un_expr).
   template <typename T>
   struct is_arg_expr : std::false_type {};
 
   template <std::size_t I>
   struct is_arg_expr<mod::arg_t<I>> : std::true_type {};
+
+  template <auto M>
+  struct is_arg_expr<mod::member_t<M>> : std::true_type {};
 
   template <typename T>
   struct is_arg_expr<mod::val_t<T>> : std::true_type {};
@@ -126,47 +135,54 @@ namespace ptn::pat::traits {
   struct is_arg_expr<mod::un_expr<Op, X>> : std::true_type {};
 
   template <typename T>
-  inline constexpr bool is_arg_expr_v = is_arg_expr<std::decay_t<T>>::value;
+  inline constexpr bool
+      is_arg_expr_v = is_arg_expr<std::decay_t<T>>::value;
 
   // Trait to detect tuple predicates.
   //
-  // Tuple predicates wrap expression templates and operate on bound tuples.
+  // Tuple predicates wrap expression templates and operate on bound
+  // tuples.
   template <typename T>
   struct is_tuple_predicate : std::false_type {};
 
   template <typename E>
-  struct is_tuple_predicate<mod::tuple_predicate<E>> : std::true_type {};
+  struct is_tuple_predicate<mod::tuple_predicate<E>>
+      : std::true_type {};
 
   template <typename T>
-  inline constexpr bool is_tuple_predicate_v =
-      is_tuple_predicate<std::decay_t<T>>::value;
+  inline constexpr bool is_tuple_predicate_v = is_tuple_predicate<
+      std::decay_t<T>>::value;
 
-  // Trait to detect tuple guard predicates (including && / || compositions).
+  // Trait to detect tuple guard predicates (including && / ||
+  // compositions).
   //
-  // Tuple guard predicates are predicates that can be called with a tuple
-  // of bound values. This includes tuple_predicate and logical compositions
-  // (pred_and, pred_or) of tuple guard predicates.
+  // Tuple guard predicates are predicates that can be called with a
+  // tuple of bound values. This includes tuple_predicate and logical
+  // compositions (pred_and, pred_or) of tuple guard predicates.
   template <typename T>
   struct is_tuple_guard_predicate : std::false_type {};
 
   template <typename E>
-  struct is_tuple_guard_predicate<mod::tuple_predicate<E>> : std::true_type {};
+  struct is_tuple_guard_predicate<mod::tuple_predicate<E>>
+      : std::true_type {};
 
   template <typename Fn>
-  struct is_tuple_guard_predicate<mod::callable_guard<Fn>> : std::true_type {};
+  struct is_tuple_guard_predicate<mod::callable_guard<Fn>>
+      : std::true_type {};
 
   template <typename T>
-  inline constexpr bool is_tuple_guard_predicate_v =
-      is_tuple_guard_predicate<std::decay_t<T>>::value;
+  inline constexpr bool
+      is_tuple_guard_predicate_v = is_tuple_guard_predicate<
+          std::decay_t<T>>::value;
 
   template <typename L, typename R>
   struct is_tuple_guard_predicate<mod::pred_and<L, R>>
-      : std::bool_constant<
-            is_tuple_guard_predicate_v<L> || is_tuple_guard_predicate_v<R>> {};
+      : std::bool_constant<is_tuple_guard_predicate_v<L>
+                           || is_tuple_guard_predicate_v<R>> {};
 
   template <typename L, typename R>
   struct is_tuple_guard_predicate<mod::pred_or<L, R>>
-      : std::bool_constant<
-            is_tuple_guard_predicate_v<L> || is_tuple_guard_predicate_v<R>> {};
+      : std::bool_constant<is_tuple_guard_predicate_v<L>
+                           || is_tuple_guard_predicate_v<R>> {};
 
 } // namespace ptn::pat::traits

--- a/include/ptn/pattern/bind.hpp
+++ b/include/ptn/pattern/bind.hpp
@@ -12,6 +12,7 @@
 #include "ptn/pattern/base/binding_base.hpp"
 #include "ptn/pattern/base/pattern_base.hpp"
 #include "ptn/pattern/structural.hpp"
+#include "ptn/pattern/modifiers/guard.hpp"
 
 #include <tuple>
 #include <type_traits>
@@ -281,6 +282,29 @@ namespace ptn::pat::base {
                 const std::remove_reference_t<Subject> &>>(),
             std::declval<typename binding_args<SubPattern,
                                                Subject>::type>()))>;
+  };
+
+  // Guards on as-binding patterns delegate member-placeholder
+  // resolution to the wrapped subpattern.
+  template <typename Tag, typename Sub>
+  struct guard_resolver<pat::detail::binding_as_pattern<Tag, Sub>> {
+    template <typename P>
+    static constexpr auto apply(P &&pred) {
+      return guard_resolver<Sub>::apply(std::forward<P>(pred));
+    }
+  };
+
+  // Guard resolver for structural binding patterns: PTN_BIND
+  // member placeholders in the guard are anchored to their
+  // member's position in the has<...> member list.
+  template <auto... Ms>
+  struct guard_resolver<pat::detail::structural_bind_pattern<
+      pat::detail::has_pattern<Ms...>>> {
+    template <typename P>
+    static constexpr auto apply(P &&pred) {
+      return pat::mod::resolve_pred(pat::mod::member_list<Ms...>{},
+                                    std::forward<P>(pred));
+    }
   };
 
   // Structural-binding pattern binds.

--- a/include/ptn/pattern/modifiers/fwd.h
+++ b/include/ptn/pattern/modifiers/fwd.h
@@ -36,6 +36,14 @@ namespace ptn::pat::mod {
   template <typename Op, typename X>
   struct un_expr;
 
+  // Forward declare member-anchored placeholder
+  template <auto M>
+  struct member_t;
+
+  // Forward declare member pointer list
+  template <auto... Ms>
+  struct member_list;
+
   // Forward declare max argument index traits
   template <typename E>
   struct max_arg_index;

--- a/include/ptn/pattern/modifiers/guard.hpp
+++ b/include/ptn/pattern/modifiers/guard.hpp
@@ -98,6 +98,19 @@ namespace ptn::pat::mod {
     return Op{}(eval(e.x, std::forward<Tuple>(t)));
   }
 
+  // Trap: member placeholders must be resolved to positional
+  // placeholders by the structural pattern owning the guard. This
+  // overload is only reached when a PTN_BIND name is used in a
+  // guard on a non-structural pattern.
+  template <auto M, typename Tuple>
+  constexpr decltype(auto) eval(const member_t<M> &, Tuple &&) {
+    static_assert(dependent_false<Tuple>::value,
+                  "[Patternia.guard] A PTN_BIND member placeholder "
+                  "was used in a guard on a non-structural pattern. "
+                  "Member names are only valid in guards attached "
+                  "to has<...>.");
+  }
+
   // Makes expression callable as predicate on bound tuples.
   template <typename Expr>
   struct tuple_predicate : traits::guard_predicate_tag {
@@ -139,6 +152,18 @@ namespace ptn::pat::mod {
   struct max_arg_index<un_expr<Op, X>>
       : std::integral_constant<std::size_t,
                                max_arg_index<X>::value> {};
+
+  // Trap with a clear message when a member placeholder leaks into
+  // the positional bounds check (non-structural guard).
+  template <auto M>
+  struct max_arg_index<member_t<M>> {
+    static_assert(dependent_false<member_t<M>>::value,
+                  "[Patternia.guard] A PTN_BIND member placeholder "
+                  "was used in a guard on a non-structural pattern. "
+                  "Member names are only valid in guards attached "
+                  "to has<...>.");
+    static constexpr std::size_t value = 0;
+  };
 
   template <typename T>
   inline constexpr std::size_t
@@ -459,6 +484,126 @@ namespace ptn::pat::mod {
         std::forward<L>(l), std::forward<R>(r)};
   }
 
+  // --- Member placeholder resolution (structural guards) ---
+
+  namespace detail {
+
+    // Type-safe member pointer equality: comparing member pointers
+    // of different types is ill-formed, so guard the comparison.
+    template <auto M, auto N, bool SameType>
+    struct member_eq_impl : std::false_type {};
+
+    template <auto M, auto N>
+    struct member_eq_impl<M, N, true> : std::bool_constant<M == N> {
+    };
+
+    template <auto M, auto N>
+    struct member_eq
+        : member_eq_impl<
+              M,
+              N,
+              (std::is_same_v<decltype(M), decltype(N)>)> {};
+
+  } // namespace detail
+
+  // Position of member M among the non-_ign members of Ms....
+  // _ign (nullptr) slots do not occupy binding positions.
+  template <auto M, auto... Ms>
+  struct member_position;
+
+  template <auto M>
+  struct member_position<M> {
+    static constexpr bool        found = false;
+    static constexpr std::size_t value = 0;
+  };
+
+  template <auto M, auto First, auto... Rest>
+  struct member_position<M, First, Rest...> {
+  private:
+    static constexpr bool
+        is_ign = std::is_null_pointer_v<decltype(First)>;
+    static constexpr bool
+        hit    = !is_ign && detail::member_eq<M, First>::value;
+    using next = member_position<M, Rest...>;
+
+  public:
+    static constexpr bool        found = hit || next::found;
+    static constexpr std::size_t value = hit ? 0
+                                             : (is_ign ? next::value
+                                                       : next::value
+                                                             + 1);
+  };
+
+  // Rewrites a guard expression tree, replacing every member_t<M>
+  // leaf with arg_t<position of M in Ms...>. All other nodes are
+  // preserved. Evaluation machinery is untouched.
+  //
+  // Fallback: non-expression nodes pass through unchanged (by
+  // value, so stored types stay decayed).
+  template <auto... Ms, typename E>
+  constexpr auto resolve_expr(member_list<Ms...>, E &&e) {
+    return std::forward<E>(e);
+  }
+
+  template <auto... Ms, auto M>
+  constexpr auto resolve_expr(member_list<Ms...>, member_t<M>) {
+    using pos = member_position<M, Ms...>;
+    static_assert(pos::found,
+                  "[Patternia.guard] A PTN_BIND name does not match "
+                  "any member listed in has<...>. Check the member "
+                  "pointers in the pattern.");
+    return arg_t<pos::value>{};
+  }
+
+  template <auto... Ms, typename Op, typename L, typename R>
+  constexpr auto resolve_expr(member_list<Ms...> ml,
+                              bin_expr<Op, L, R> e) {
+    auto l = resolve_expr(ml, e.l);
+    auto r = resolve_expr(ml, e.r);
+    return bin_expr<Op, decltype(l), decltype(r)>{std::move(l),
+                                                  std::move(r)};
+  }
+
+  template <auto... Ms, typename Op, typename X>
+  constexpr auto resolve_expr(member_list<Ms...> ml,
+                              un_expr<Op, X>     e) {
+    auto x = resolve_expr(ml, e.x);
+    return un_expr<Op, decltype(x)>{std::move(x)};
+  }
+
+  // Rewrites a full guard predicate. Expression predicates
+  // (tuple_predicate) and logical compositions (pred_and/pred_or)
+  // are rewritten; callables and other predicates pass through.
+  template <auto... Ms, typename P>
+  constexpr auto resolve_pred(member_list<Ms...>, P &&p) {
+    return std::forward<P>(p);
+  }
+
+  template <auto... Ms, typename E>
+  constexpr auto resolve_pred(member_list<Ms...> ml,
+                              tuple_predicate<E> p) {
+    auto e = resolve_expr(ml, std::move(p.expr));
+    return tuple_predicate<decltype(e)>{std::move(e)};
+  }
+
+  template <auto... Ms, typename L, typename R>
+  constexpr auto resolve_pred(member_list<Ms...> ml,
+                              pred_and<L, R>     p) {
+    auto l = resolve_pred(ml, std::move(p.lhs));
+    auto r = resolve_pred(ml, std::move(p.rhs));
+    return pred_and<decltype(l), decltype(r)>{std::move(l),
+                                              std::move(r)};
+  }
+
+  template <auto... Ms, typename L, typename R>
+  constexpr auto resolve_pred(member_list<Ms...> ml,
+                              pred_or<L, R>      p) {
+    auto l = resolve_pred(ml, std::move(p.lhs));
+    auto r = resolve_pred(ml, std::move(p.rhs));
+    return pred_or<decltype(l), decltype(r)>{std::move(l),
+                                             std::move(r)};
+  }
+
   // Range modes for interval predicates.
   enum class range_mode {
     closed,
@@ -597,6 +742,16 @@ namespace ptn::pat::mod {
 } // namespace ptn::pat::mod
 
 namespace ptn::pat::base {
+
+  // Guards on already-guarded patterns delegate member-placeholder
+  // resolution to the inner pattern (chained guard support).
+  template <typename Inner, typename Pred>
+  struct guard_resolver<mod::guarded_pattern<Inner, Pred>> {
+    template <typename P>
+    static constexpr auto apply(P &&pred) {
+      return guard_resolver<Inner>::apply(std::forward<P>(pred));
+    }
+  };
 
   // Binding contract specialization for guarded_pattern.
   template <typename Inner, typename Pred, typename Subject>

--- a/include/ptn/pattern/modifiers/placeholder.hpp
+++ b/include/ptn/pattern/modifiers/placeholder.hpp
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <cstddef>
+#include <type_traits>
 
 namespace ptn::pat::mod {
 
@@ -9,6 +10,27 @@ namespace ptn::pat::mod {
   struct arg_t {
     static constexpr std::size_t index = I;
   };
+
+  // Member-anchored placeholder for structural guards.
+  //
+  // A PTN_BIND name expands to member_t<&Type::member>. Inside a
+  // guard attached to has<...>, the structural pattern resolves
+  // the member pointer to the position of that member in its
+  // member list at compile time, so guard names follow members,
+  // not the order of pointers in has<...>.
+  template <auto M>
+  struct member_t {
+    static constexpr auto member = M;
+  };
+
+  // Type-level list of member pointers (including _ign slots)
+  // describing the member order of a structural pattern.
+  template <auto... Ms>
+  struct member_list {};
+
+  // Dependent false for static_assert inside templates.
+  template <typename>
+  struct dependent_false : std::false_type {};
 
   // Computes the largest binding position referenced by an
   // expression.

--- a/include/ptn/pattern/structural.hpp
+++ b/include/ptn/pattern/structural.hpp
@@ -11,6 +11,7 @@
 #include "ptn/pattern/base/fwd.h"
 #include "ptn/pattern/base/pattern_base.hpp"
 #include "ptn/pattern/base/pattern_traits.hpp"
+#include "ptn/pattern/modifiers/guard.hpp"
 #include "ptn/core/common/diagnostics.hpp"
 
 namespace ptn::pat {
@@ -130,13 +131,18 @@ namespace ptn::pat {
     }
 
     // Deferred definition of has_pattern::operator[].
+    // PTN_BIND member placeholders in the guard are resolved
+    // against this pattern's member list.
     template <auto... Ms>
     template <typename Pred>
     constexpr auto
     has_pattern<Ms...>::operator[](Pred &&pred) const {
+      auto resolved = ptn::pat::mod::resolve_pred(
+          ptn::pat::mod::member_list<Ms...>{},
+          std::forward<Pred>(pred));
       return has_guarded_pattern<has_pattern<Ms...>,
-                                 std::decay_t<Pred>>{
-          std::forward<Pred>(pred)};
+                                 decltype(resolved)>{
+          std::move(resolved)};
     }
 
   } // namespace detail

--- a/include/ptn/pattern/type.hpp
+++ b/include/ptn/pattern/type.hpp
@@ -289,3 +289,26 @@ namespace ptn::pat::base {
   };
 
 } // namespace ptn::pat::base
+
+namespace ptn::pat::base {
+
+  // Guards on type patterns delegate member-placeholder
+  // resolution to the wrapped subpattern, so PTN_BIND names work
+  // through is<T>(...) / alt<I>(...) wrappers.
+  template <typename T, typename Sub>
+  struct guard_resolver<ptn::pat::detail::type_is_pattern<T, Sub>> {
+    template <typename P>
+    static constexpr auto apply(P &&pred) {
+      return guard_resolver<Sub>::apply(std::forward<P>(pred));
+    }
+  };
+
+  template <std::size_t I, typename Sub>
+  struct guard_resolver<ptn::pat::detail::type_alt_pattern<I, Sub>> {
+    template <typename P>
+    static constexpr auto apply(P &&pred) {
+      return guard_resolver<Sub>::apply(std::forward<P>(pred));
+    }
+  };
+
+} // namespace ptn::pat::base

--- a/include/ptn/patternia.hpp
+++ b/include/ptn/patternia.hpp
@@ -89,11 +89,16 @@ namespace ptn {
 
 // PTN_BIND(Type, member0, member1, ...)
 //
-// Declares named placeholder objects for use in guard expressions.
-// Each name is a constexpr arg_t<N> where N is the zero-based
-// position of the member in the argument list. Declarations are
-// valid at namespace or block scope, so names can stay close to a
-// match.
+// Declares member-anchored named placeholders for use in guard
+// expressions attached to has<...>. Each name must designate a
+// non-static data member of Type: the macro expands name to
+// constexpr member_t<&Type::name>. Declarations are valid at
+// namespace or block scope.
+//
+// Inside a guard, names resolve to the position of their member
+// in the has<...> member list at compile time. They follow
+// members, not positions, so the order of member pointers in
+// has<...> does not matter.
 //
 // Example:
 //   struct Point { int x; int y; };
@@ -104,11 +109,9 @@ namespace ptn {
 //           >> [](auto& p) { return dist(p); }
 //   );
 //
-// NOTE: The Type argument is currently unused by the generated code.
-// It serves as documentation: the names are expected to correspond
-// to the members of Type, listed in the same order as in has<...>.
-// A future reflection-based variant may validate this at compile
-// time.
+// A misspelled member name fails at the PTN_BIND line, and a name
+// used with a has<...> that does not list its member fails a
+// static_assert.
 //
 // Supports 1 to 10 member names.
 //
@@ -117,47 +120,47 @@ namespace ptn {
 // - PTN_BIND_N is defined by chaining: it expands to
 //   PTN_BIND_{N-1} plus one more declaration, so adding a new
 //   arity only costs one short macro instead of a full rewrite.
-#define PTN_BIND_DECL(Index, name)                                  \
-  constexpr ::ptn::pat::mod::arg_t<Index> name{};
+#define PTN_BIND_DECL(Type, name)                                   \
+  constexpr ::ptn::pat::mod::member_t<&Type::name> name{};
 
-#define PTN_BIND_1(Type, m0) PTN_BIND_DECL(0, m0)
+#define PTN_BIND_1(Type, m0) PTN_BIND_DECL(Type, m0)
 
 #define PTN_BIND_2(Type, m0, m1)                                    \
   PTN_BIND_EXPAND(PTN_BIND_1(Type, m0))                             \
-  PTN_BIND_DECL(1, m1)
+  PTN_BIND_DECL(Type, m1)
 
 #define PTN_BIND_3(Type, m0, m1, m2)                                \
   PTN_BIND_EXPAND(PTN_BIND_2(Type, m0, m1))                         \
-  PTN_BIND_DECL(2, m2)
+  PTN_BIND_DECL(Type, m2)
 
 #define PTN_BIND_4(Type, m0, m1, m2, m3)                            \
   PTN_BIND_EXPAND(PTN_BIND_3(Type, m0, m1, m2))                     \
-  PTN_BIND_DECL(3, m3)
+  PTN_BIND_DECL(Type, m3)
 
 #define PTN_BIND_5(Type, m0, m1, m2, m3, m4)                        \
   PTN_BIND_EXPAND(PTN_BIND_4(Type, m0, m1, m2, m3))                 \
-  PTN_BIND_DECL(4, m4)
+  PTN_BIND_DECL(Type, m4)
 
 #define PTN_BIND_6(Type, m0, m1, m2, m3, m4, m5)                    \
   PTN_BIND_EXPAND(PTN_BIND_5(Type, m0, m1, m2, m3, m4))             \
-  PTN_BIND_DECL(5, m5)
+  PTN_BIND_DECL(Type, m5)
 
 #define PTN_BIND_7(Type, m0, m1, m2, m3, m4, m5, m6)                \
   PTN_BIND_EXPAND(PTN_BIND_6(Type, m0, m1, m2, m3, m4, m5))         \
-  PTN_BIND_DECL(6, m6)
+  PTN_BIND_DECL(Type, m6)
 
 #define PTN_BIND_8(Type, m0, m1, m2, m3, m4, m5, m6, m7)            \
   PTN_BIND_EXPAND(PTN_BIND_7(Type, m0, m1, m2, m3, m4, m5, m6))     \
-  PTN_BIND_DECL(7, m7)
+  PTN_BIND_DECL(Type, m7)
 
 #define PTN_BIND_9(Type, m0, m1, m2, m3, m4, m5, m6, m7, m8)        \
   PTN_BIND_EXPAND(PTN_BIND_8(Type, m0, m1, m2, m3, m4, m5, m6, m7)) \
-  PTN_BIND_DECL(8, m8)
+  PTN_BIND_DECL(Type, m8)
 
 #define PTN_BIND_10(Type, m0, m1, m2, m3, m4, m5, m6, m7, m8, m9)   \
   PTN_BIND_EXPAND(                                                  \
       PTN_BIND_9(Type, m0, m1, m2, m3, m4, m5, m6, m7, m8))         \
-  PTN_BIND_DECL(9, m9)
+  PTN_BIND_DECL(Type, m9)
 
 #define PTN_BIND_PICK(                                              \
     _1, _2, _3, _4, _5, _6, _7, _8, _9, _10, NAME, ...)             \

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -60,6 +60,9 @@ set(PTN_COMPILE_FAIL_CASES
   compile_fail/static_on_with_capture.cpp
   compile_fail/on_pipeline_without_wildcard.cpp
   compile_fail/val_requires_compile_time_constant.cpp
+  compile_fail/member_placeholder_not_in_pattern.cpp
+  compile_fail/member_placeholder_non_structural.cpp
+  compile_fail/ptn_bind_unknown_member.cpp
 )
 
 if(CMAKE_CXX_STANDARD LESS 20)

--- a/tests/compile_fail/member_placeholder_non_structural.cpp
+++ b/tests/compile_fail/member_placeholder_non_structural.cpp
@@ -1,0 +1,16 @@
+#include <ptn/patternia.hpp>
+
+struct Point {
+  int x;
+  int y;
+};
+
+PTN_BIND(Point, x, y);
+
+int main() {
+  int v = 3;
+  // Member placeholders are only valid in guards attached to
+  // has<...>. Using one on a non-structural pattern must fail.
+  auto r = ptn::match(v) | ptn::on(ptn::$[x > 0] >> 1, ptn::_ >> 0);
+  return r;
+}

--- a/tests/compile_fail/member_placeholder_not_in_pattern.cpp
+++ b/tests/compile_fail/member_placeholder_not_in_pattern.cpp
@@ -1,0 +1,18 @@
+#include <ptn/patternia.hpp>
+
+struct Point {
+  int x;
+  int y;
+};
+
+PTN_BIND(Point, x, y);
+
+int main() {
+  Point p{3, 4};
+  // has<...> does not list &Point::y, so the member placeholder
+  // y cannot be resolved: static_assert must fire.
+  auto r = ptn::match(p)
+           | ptn::on(ptn::$(ptn::has<&Point::x>)[y > 0] >> 1,
+                     ptn::_ >> 0);
+  return r;
+}

--- a/tests/compile_fail/ptn_bind_unknown_member.cpp
+++ b/tests/compile_fail/ptn_bind_unknown_member.cpp
@@ -1,0 +1,14 @@
+#include <ptn/patternia.hpp>
+
+struct Point {
+  int x;
+  int y;
+};
+
+// PTN_BIND names must be members of the given type; a misspelled
+// member name must fail right at the declaration.
+PTN_BIND(Point, xx);
+
+int main() {
+  return 0;
+}

--- a/tests/tests_destructure.cpp
+++ b/tests/tests_destructure.cpp
@@ -18,8 +18,8 @@ struct Packet {
   std::string payload;
 };
 
-PTN_BIND(Point, point_x, point_y);
-PTN_BIND(Packet, packet_type, packet_length);
+PTN_BIND(Point, x, y);
+PTN_BIND(Packet, type, length);
 
 // -- $(has<>) destructure binding --
 
@@ -40,9 +40,8 @@ TEST(Destructure, WithGuard) {
 
   int result = match(p)
                | on(
-                   $(has<&Point::x, &Point::y>)[point_x > 0
-                                                && point_y > 0]
-                       >> [](int x, int y) { return x * y; },
+                   $(has<&Point::x, &Point::y>)[x > 0 && y > 0] >>
+                       [](int x, int y) { return x * y; },
                    _ >> -1);
 
   EXPECT_EQ(result, 50);
@@ -53,9 +52,8 @@ TEST(Destructure, GuardRejects) {
 
   int result = match(p)
                | on(
-                   $(has<&Point::x, &Point::y>)[point_x > 0
-                                                && point_y > 0]
-                       >> [](int x, int y) { return x * y; },
+                   $(has<&Point::x, &Point::y>)[x > 0 && y > 0] >>
+                       [](int x, int y) { return x * y; },
                    _ >> -1);
 
   EXPECT_EQ(result, -1);
@@ -137,8 +135,7 @@ TEST(HasGuard, MultiMemberGuard) {
   int result = match(pkt)
                | on(
                    has<&Packet::type,
-                       &Packet::length>[packet_type == 0x01
-                                        && packet_length == 0]
+                       &Packet::length>[type == 0x01 && length == 0]
                        >> [] { return 1; },
                    _ >> 0);
 

--- a/tests/tests_named_placeholder.cpp
+++ b/tests/tests_named_placeholder.cpp
@@ -1,12 +1,14 @@
 // Tests for PTN_BIND named placeholder macro.
 //
-// Verifies that PTN_BIND declares readable names for bound tuple
-// positions. All tests exercise the full match pipeline
-// (match | on($[guard] >> handler)) end to end.
+// Verifies that PTN_BIND declares member-anchored names for use in
+// structural guard expressions. All tests exercise the full match
+// pipeline (match | on(pattern[guard] >> handler)) end to end.
 
 #include <gtest/gtest.h>
 
 #include "ptn/patternia.hpp"
+
+#include <variant>
 
 // Test fixture structs.
 namespace {
@@ -59,15 +61,15 @@ namespace {
     int j;
   };
 
-  // Declare named placeholders for each struct.
-  // These are constexpr arg_t<N> objects.
+  // Member-anchored placeholders declared at namespace scope.
+  // Names must be real members of the given struct, and names in
+  // one scope must be unique, so structs with overlapping member
+  // names (Triple/Quad/Penta/Deca) bind at block scope inside the
+  // tests that need them.
   PTN_BIND(Point, x, y);
   PTN_BIND(Packet, type, len);
   PTN_BIND(Triple, a, b, c);
-  PTN_BIND(Single, sv);
-  PTN_BIND(Quad, qa, qb, qc, qd);
-  PTN_BIND(Penta, pa, pb, pc, pd, pe);
-  PTN_BIND(Deca, da, db, dc, dd, de, df, dg, dh, di, dj);
+  PTN_BIND(Single, value);
 
 } // namespace
 
@@ -91,29 +93,29 @@ TEST(NamedPlaceholder, SupportsBlockScopeDeclarations) {
 }
 
 // =========================================================================
-// Type correctness: PTN_BIND names must be arg_t<N> of the right
-// index.
+// Type correctness: PTN_BIND names must be
+// member_t<&Struct::member>.
 // =========================================================================
 
-TEST(NamedPlaceholder, SingleArgTypeMatchesArg0) {
+TEST(NamedPlaceholder, SingleArgTypeMatchesMember) {
   static_assert(std::is_same_v<std::decay_t<decltype(x)>,
-                               ptn::pat::mod::arg_t<0>>);
+                               ptn::pat::mod::member_t<&Point::x>>);
 }
 
-TEST(NamedPlaceholder, TwoArgTypesMatchPositions) {
+TEST(NamedPlaceholder, TwoArgTypesMatchMembers) {
   static_assert(std::is_same_v<std::decay_t<decltype(x)>,
-                               ptn::pat::mod::arg_t<0>>);
+                               ptn::pat::mod::member_t<&Point::x>>);
   static_assert(std::is_same_v<std::decay_t<decltype(y)>,
-                               ptn::pat::mod::arg_t<1>>);
+                               ptn::pat::mod::member_t<&Point::y>>);
 }
 
-TEST(NamedPlaceholder, ThreeArgTypesMatchPositions) {
+TEST(NamedPlaceholder, ThreeArgTypesMatchMembers) {
   static_assert(std::is_same_v<std::decay_t<decltype(a)>,
-                               ptn::pat::mod::arg_t<0>>);
+                               ptn::pat::mod::member_t<&Triple::a>>);
   static_assert(std::is_same_v<std::decay_t<decltype(b)>,
-                               ptn::pat::mod::arg_t<1>>);
+                               ptn::pat::mod::member_t<&Triple::b>>);
   static_assert(std::is_same_v<std::decay_t<decltype(c)>,
-                               ptn::pat::mod::arg_t<2>>);
+                               ptn::pat::mod::member_t<&Triple::c>>);
 }
 
 // =========================================================================
@@ -123,7 +125,7 @@ TEST(NamedPlaceholder, ThreeArgTypesMatchPositions) {
 TEST(NamedPlaceholder, SingleValueUsesWildcardPlaceholder) {
   int  val    = 10;
   auto result = ptn::match(val)
-                | PTN_ON(
+                | ptn::on(
                     ptn::$[ptn::_ > 5] >>
                         [](int v) { return v * 2; },
                     ptn::_ >> 0);
@@ -133,7 +135,7 @@ TEST(NamedPlaceholder, SingleValueUsesWildcardPlaceholder) {
 TEST(NamedPlaceholder, SingleValueWildcardGuardFails) {
   int  val    = 3;
   auto result = ptn::match(val)
-                | PTN_ON(
+                | ptn::on(
                     ptn::$[ptn::_ > 5] >>
                         [](int v) { return v * 2; },
                     ptn::_ >> 0);
@@ -143,7 +145,7 @@ TEST(NamedPlaceholder, SingleValueWildcardGuardFails) {
 TEST(NamedPlaceholder, StructuralGuardTwoMembers) {
   Point p{3, 4};
   auto  result = ptn::match(p)
-                | PTN_ON(
+                | ptn::on(
                     ptn::$(ptn::has<&Point::x,
                                     &Point::y>)[x * x + y * y == 25]
                         >> 1,
@@ -154,7 +156,7 @@ TEST(NamedPlaceholder, StructuralGuardTwoMembers) {
 TEST(NamedPlaceholder, StructuralGuardFails) {
   Point p{1, 1};
   auto  result = ptn::match(p)
-                | PTN_ON(
+                | ptn::on(
                     ptn::$(ptn::has<&Point::x,
                                     &Point::y>)[x * x + y * y == 25]
                         >> 1,
@@ -166,7 +168,7 @@ TEST(NamedPlaceholder, StructuralGuardLessThan) {
   // x < y
   Point p{3, 7};
   auto  result = ptn::match(p)
-                | PTN_ON(
+                | ptn::on(
                     ptn::$(ptn::has<&Point::x, &Point::y>)[x < y]
                         >> 1,
                     ptn::_ >> 0);
@@ -177,7 +179,7 @@ TEST(NamedPlaceholder, StructuralGuardEquality) {
   // type == 0x01
   Packet pkt{0x01, 42};
   auto   result = ptn::match(pkt)
-                | PTN_ON(
+                | ptn::on(
                     ptn::$(ptn::has<&Packet::type>)[type == 1] >> 1,
                     ptn::_ >> 0);
   EXPECT_EQ(result, 1);
@@ -187,7 +189,7 @@ TEST(NamedPlaceholder, StructuralGuardCompound) {
   // type == 0x01 && len > 0
   Packet pkt{0x01, 42};
   auto   result = ptn::match(pkt)
-                | PTN_ON(
+                | ptn::on(
                     ptn::$(
                         ptn::has<&Packet::type,
                                  &Packet::len>)[type == 1 && len > 0]
@@ -200,22 +202,133 @@ TEST(NamedPlaceholder, ThreeMemberGuard) {
   // a + b == c
   Triple t{2, 3, 5};
   auto   result = ptn::match(t)
-                | PTN_ON(ptn::$(ptn::has<&Triple::a,
-                                         &Triple::b,
-                                         &Triple::c>)[a + b == c]
-                             >> 1,
-                         ptn::_ >> 0);
+                | ptn::on(ptn::$(ptn::has<&Triple::a,
+                                          &Triple::b,
+                                          &Triple::c>)[a + b == c]
+                              >> 1,
+                          ptn::_ >> 0);
   EXPECT_EQ(result, 1);
 }
 
 TEST(NamedPlaceholder, ThreeMemberGuardFails) {
   Triple t{2, 3, 6};
   auto   result = ptn::match(t)
-                | PTN_ON(ptn::$(ptn::has<&Triple::a,
-                                         &Triple::b,
-                                         &Triple::c>)[a + b == c]
-                             >> 1,
-                         ptn::_ >> 0);
+                | ptn::on(ptn::$(ptn::has<&Triple::a,
+                                          &Triple::b,
+                                          &Triple::c>)[a + b == c]
+                              >> 1,
+                          ptn::_ >> 0);
+  EXPECT_EQ(result, 0);
+}
+
+// =========================================================================
+// Member anchoring: names follow members, not positions.
+// =========================================================================
+
+TEST(NamedPlaceholder, NamesFollowMembersNotPositions) {
+  // has<> lists members in reverse order; names still resolve to
+  // their own member. Positionally this guard would read
+  // (.y == 3 && .x == 4) and fail.
+  Point p{3, 4};
+  auto  result = ptn::match(p)
+                | ptn::on(
+                    ptn::$(ptn::has<&Point::y, &Point::x>)[x == 3
+                                                           && y == 4]
+                        >> 1,
+                    ptn::_ >> 0);
+  EXPECT_EQ(result, 1);
+}
+
+TEST(NamedPlaceholder, PositionalReadingWouldDiffer) {
+  // Same reversed pattern with the positionally-read guard: it
+  // must NOT match, proving resolution is by member.
+  Point p{3, 4};
+  auto  result = ptn::match(p)
+                | ptn::on(
+                    ptn::$(ptn::has<&Point::y, &Point::x>)[x == 4
+                                                           && y == 3]
+                        >> 1,
+                    ptn::_ >> 0);
+  EXPECT_EQ(result, 0);
+}
+
+TEST(NamedPlaceholder, MemberNamesSkipIgnoredSlots) {
+  // _ign occupies a pattern slot but no binding position, so
+  // c resolves to position 1 of the extracted tuple.
+  Triple t{2, 99, 5};
+  auto   result = ptn::match(t)
+                | ptn::on(ptn::$(ptn::has<&Triple::a,
+                                          ptn::_ign,
+                                          &Triple::c>)[a + c == 7]
+                              >> 1,
+                          ptn::_ >> 0);
+  EXPECT_EQ(result, 1);
+}
+
+TEST(NamedPlaceholder, MixedWildcardAndMemberNames) {
+  // `_` keeps its positional meaning (position 0 == .x) and can be
+  // combined with member-anchored names.
+  Point p{3, 4};
+  auto  result = ptn::match(p)
+                | ptn::on(
+                    ptn::$(
+                        ptn::has<&Point::x, &Point::y>)[ptn::_ == 3
+                                                        && y == 4]
+                        >> 1,
+                    ptn::_ >> 0);
+  EXPECT_EQ(result, 1);
+}
+
+TEST(NamedPlaceholder, NonBindingGuardWithMemberNames) {
+  // has<>[guard] without binding: handler is nullary, names still
+  // anchor to members.
+  Packet pkt{0x01, 42};
+  auto   result = ptn::match(pkt)
+                | ptn::on(
+                    ptn::has<&Packet::type, &Packet::len>[type == 1
+                                                          && len > 0]
+                        >> 1,
+                    ptn::_ >> 0);
+  EXPECT_EQ(result, 1);
+}
+
+TEST(NamedPlaceholder, NonBindingGuardRejects) {
+  Packet pkt{0x02, 42};
+  auto   result = ptn::match(pkt)
+                | ptn::on(
+                    ptn::has<&Packet::type, &Packet::len>[type == 1
+                                                          && len > 0]
+                        >> 1,
+                    ptn::_ >> 0);
+  EXPECT_EQ(result, 0);
+}
+
+TEST(NamedPlaceholder, GuardOnTypePatternWithStructuralSub) {
+  // Member names resolve through is<T>(...) wrappers: the guard
+  // attaches to the type pattern but anchors to the members of
+  // the nested has<...>.
+  using V     = std::variant<int, Point>;
+  V    v      = Point{3, 4};
+  auto result = ptn::match(v)
+                | ptn::on(
+                    ptn::is<Point>(ptn::$(
+                        ptn::has<&Point::x, &Point::y>))[x == 3
+                                                         && y == 4]
+                        >> [](int px, int py) { return px + py; },
+                    ptn::_ >> [] { return 0; });
+  EXPECT_EQ(result, 7);
+}
+
+TEST(NamedPlaceholder, GuardOnTypePatternRejects) {
+  using V     = std::variant<int, Point>;
+  V    v      = Point{3, -4};
+  auto result = ptn::match(v)
+                | ptn::on(
+                    ptn::is<Point>(ptn::$(
+                        ptn::has<&Point::x, &Point::y>))[x > 0
+                                                         && y > 0]
+                        >> [](int px, int py) { return px + py; },
+                    ptn::_ >> [] { return 0; });
   EXPECT_EQ(result, 0);
 }
 
@@ -227,7 +340,7 @@ TEST(NamedPlaceholder, ArithmeticThenCompare) {
   // x + y > 5
   Point p{3, 4};
   auto  result = ptn::match(p)
-                | PTN_ON(
+                | ptn::on(
                     ptn::$(ptn::has<&Point::x, &Point::y>)[x + y > 5]
                         >> 1,
                     ptn::_ >> 0);
@@ -238,10 +351,10 @@ TEST(NamedPlaceholder, MixedArithmeticAndComparison) {
   // x*x + y*y < 50 && x < y
   Point p{3, 4};
   auto  result = ptn::match(p)
-                | PTN_ON(ptn::$(ptn::has<&Point::x, &Point::y>)
-                                 [x * x + y * y < 50 && x < y]
-                             >> 1,
-                         ptn::_ >> 0);
+                | ptn::on(ptn::$(ptn::has<&Point::x, &Point::y>)
+                                  [x * x + y * y < 50 && x < y]
+                              >> 1,
+                          ptn::_ >> 0);
   EXPECT_EQ(result, 1);
 }
 
@@ -250,15 +363,16 @@ TEST(NamedPlaceholder, MixedArithmeticAndComparison) {
 // =========================================================================
 
 TEST(NamedPlaceholder, OneMemberTypeCorrect) {
-  static_assert(std::is_same_v<std::decay_t<decltype(sv)>,
-                               ptn::pat::mod::arg_t<0>>);
+  static_assert(
+      std::is_same_v<std::decay_t<decltype(value)>,
+                     ptn::pat::mod::member_t<&Single::value>>);
 }
 
 TEST(NamedPlaceholder, OneMemberGuard) {
   Single s{42};
   auto   result = ptn::match(s)
-                | PTN_ON(
-                    ptn::$(ptn::has<&Single::value>)[sv > 5] >> 1,
+                | ptn::on(
+                    ptn::$(ptn::has<&Single::value>)[value > 5] >> 1,
                     ptn::_ >> 0);
   EXPECT_EQ(result, 1);
 }
@@ -266,79 +380,81 @@ TEST(NamedPlaceholder, OneMemberGuard) {
 TEST(NamedPlaceholder, OneMemberGuardFails) {
   Single s{3};
   auto   result = ptn::match(s)
-                | PTN_ON(
-                    ptn::$(ptn::has<&Single::value>)[sv > 5] >> 1,
+                | ptn::on(
+                    ptn::$(ptn::has<&Single::value>)[value > 5] >> 1,
                     ptn::_ >> 0);
   EXPECT_EQ(result, 0);
 }
 
 TEST(NamedPlaceholder, FourMemberTypeCorrect) {
-  static_assert(std::is_same_v<std::decay_t<decltype(qa)>,
-                               ptn::pat::mod::arg_t<0>>);
-  static_assert(std::is_same_v<std::decay_t<decltype(qd)>,
-                               ptn::pat::mod::arg_t<3>>);
+  PTN_BIND(Quad, a, b, c, d);
+  static_assert(std::is_same_v<std::decay_t<decltype(a)>,
+                               ptn::pat::mod::member_t<&Quad::a>>);
+  static_assert(std::is_same_v<std::decay_t<decltype(d)>,
+                               ptn::pat::mod::member_t<&Quad::d>>);
 }
 
 TEST(NamedPlaceholder, FourMemberGuard) {
   // a + b + c == d
+  PTN_BIND(Quad, a, b, c, d);
   Quad q{1, 2, 3, 6};
   auto result = ptn::match(q)
-                | PTN_ON(
-                    ptn::$(ptn::has<&Quad::a,
-                                    &Quad::b,
-                                    &Quad::c,
-                                    &Quad::d>)[qa + qb + qc == qd]
-                        >> 1,
-                    ptn::_ >> 0);
+                | ptn::on(ptn::$(ptn::has<&Quad::a,
+                                          &Quad::b,
+                                          &Quad::c,
+                                          &Quad::d>)[a + b + c == d]
+                              >> 1,
+                          ptn::_ >> 0);
   EXPECT_EQ(result, 1);
 }
 
 TEST(NamedPlaceholder, FourMemberGuardFails) {
+  PTN_BIND(Quad, a, b, c, d);
   Quad q{1, 2, 3, 7};
   auto result = ptn::match(q)
-                | PTN_ON(
-                    ptn::$(ptn::has<&Quad::a,
-                                    &Quad::b,
-                                    &Quad::c,
-                                    &Quad::d>)[qa + qb + qc == qd]
-                        >> 1,
-                    ptn::_ >> 0);
+                | ptn::on(ptn::$(ptn::has<&Quad::a,
+                                          &Quad::b,
+                                          &Quad::c,
+                                          &Quad::d>)[a + b + c == d]
+                              >> 1,
+                          ptn::_ >> 0);
   EXPECT_EQ(result, 0);
 }
 
 TEST(NamedPlaceholder, FiveMemberTypeCorrect) {
-  static_assert(std::is_same_v<std::decay_t<decltype(pa)>,
-                               ptn::pat::mod::arg_t<0>>);
-  static_assert(std::is_same_v<std::decay_t<decltype(pe)>,
-                               ptn::pat::mod::arg_t<4>>);
+  PTN_BIND(Penta, a, b, c, d, e);
+  static_assert(std::is_same_v<std::decay_t<decltype(a)>,
+                               ptn::pat::mod::member_t<&Penta::a>>);
+  static_assert(std::is_same_v<std::decay_t<decltype(e)>,
+                               ptn::pat::mod::member_t<&Penta::e>>);
 }
 
 TEST(NamedPlaceholder, FiveMemberGuard) {
   // a * b - c == d + e
+  PTN_BIND(Penta, a, b, c, d, e);
   Penta p{6, 2, 5, 4, 3};
   auto  result = ptn::match(p)
-                | PTN_ON(
-                    ptn::$(
-                        ptn::has<&Penta::a,
-                                 &Penta::b,
-                                 &Penta::c,
-                                 &Penta::d,
-                                 &Penta::e>)[pa * pb - pc == pd + pe]
+                | ptn::on(
+                    ptn::$(ptn::has<&Penta::a,
+                                    &Penta::b,
+                                    &Penta::c,
+                                    &Penta::d,
+                                    &Penta::e>)[a * b - c == d + e]
                         >> 1,
                     ptn::_ >> 0);
   EXPECT_EQ(result, 1);
 }
 
 TEST(NamedPlaceholder, FiveMemberGuardFails) {
+  PTN_BIND(Penta, a, b, c, d, e);
   Penta p{6, 2, 5, 4, 4};
   auto  result = ptn::match(p)
-                | PTN_ON(
-                    ptn::$(
-                        ptn::has<&Penta::a,
-                                 &Penta::b,
-                                 &Penta::c,
-                                 &Penta::d,
-                                 &Penta::e>)[pa * pb - pc == pd + pe]
+                | ptn::on(
+                    ptn::$(ptn::has<&Penta::a,
+                                    &Penta::b,
+                                    &Penta::c,
+                                    &Penta::d,
+                                    &Penta::e>)[a * b - c == d + e]
                         >> 1,
                     ptn::_ >> 0);
   EXPECT_EQ(result, 0);
@@ -351,48 +467,48 @@ TEST(NamedPlaceholder, FiveMemberGuardFails) {
 TEST(NamedPlaceholder, BindThreeArgGuard) {
   Triple t{2, 3, 5};
   auto   result = ptn::match(t)
-                | PTN_ON(ptn::$(ptn::has<&Triple::a,
-                                         &Triple::b,
-                                         &Triple::c>)[a + b == c]
-                             >> 1,
-                         ptn::_ >> 0);
+                | ptn::on(ptn::$(ptn::has<&Triple::a,
+                                          &Triple::b,
+                                          &Triple::c>)[a + b == c]
+                              >> 1,
+                          ptn::_ >> 0);
   EXPECT_EQ(result, 1);
 }
 
 TEST(NamedPlaceholder, BindThreeArgGuardFails) {
   Triple t{2, 3, 6};
   auto   result = ptn::match(t)
-                | PTN_ON(ptn::$(ptn::has<&Triple::a,
-                                         &Triple::b,
-                                         &Triple::c>)[a + b == c]
-                             >> 1,
-                         ptn::_ >> 0);
+                | ptn::on(ptn::$(ptn::has<&Triple::a,
+                                          &Triple::b,
+                                          &Triple::c>)[a + b == c]
+                              >> 1,
+                          ptn::_ >> 0);
   EXPECT_EQ(result, 0);
 }
 
 TEST(NamedPlaceholder, BindFourArgGuard) {
+  PTN_BIND(Quad, a, b, c, d);
   Quad q{1, 2, 3, 6};
   auto result = ptn::match(q)
-                | PTN_ON(
-                    ptn::$(ptn::has<&Quad::a,
-                                    &Quad::b,
-                                    &Quad::c,
-                                    &Quad::d>)[qa + qb + qc == qd]
-                        >> 1,
-                    ptn::_ >> 0);
+                | ptn::on(ptn::$(ptn::has<&Quad::a,
+                                          &Quad::b,
+                                          &Quad::c,
+                                          &Quad::d>)[a + b + c == d]
+                              >> 1,
+                          ptn::_ >> 0);
   EXPECT_EQ(result, 1);
 }
 
 TEST(NamedPlaceholder, BindFourArgGuardFails) {
+  PTN_BIND(Quad, a, b, c, d);
   Quad q{1, 2, 3, 7};
   auto result = ptn::match(q)
-                | PTN_ON(
-                    ptn::$(ptn::has<&Quad::a,
-                                    &Quad::b,
-                                    &Quad::c,
-                                    &Quad::d>)[qa + qb + qc == qd]
-                        >> 1,
-                    ptn::_ >> 0);
+                | ptn::on(ptn::$(ptn::has<&Quad::a,
+                                          &Quad::b,
+                                          &Quad::c,
+                                          &Quad::d>)[a + b + c == d]
+                              >> 1,
+                          ptn::_ >> 0);
   EXPECT_EQ(result, 0);
 }
 
@@ -401,52 +517,53 @@ TEST(NamedPlaceholder, BindFourArgGuardFails) {
 // =========================================================================
 
 TEST(NamedPlaceholder, TenMemberTypeCorrect) {
-  static_assert(std::is_same_v<std::decay_t<decltype(da)>,
-                               ptn::pat::mod::arg_t<0>>);
-  static_assert(std::is_same_v<std::decay_t<decltype(dj)>,
-                               ptn::pat::mod::arg_t<9>>);
+  PTN_BIND(Deca, a, b, c, d, e, f, g, h, i, j);
+  static_assert(std::is_same_v<std::decay_t<decltype(a)>,
+                               ptn::pat::mod::member_t<&Deca::a>>);
+  static_assert(std::is_same_v<std::decay_t<decltype(j)>,
+                               ptn::pat::mod::member_t<&Deca::j>>);
 }
 
 TEST(NamedPlaceholder, TenMemberGuard) {
   // a + b + ... + i == j
-  Deca d{1, 1, 1, 1, 1, 1, 1, 1, 1, 9};
-  auto result = ptn::match(d)
-                | PTN_ON(
-                    ptn::$(
-                        ptn::has<&Deca::a,
-                                 &Deca::b,
-                                 &Deca::c,
-                                 &Deca::d,
-                                 &Deca::e,
-                                 &Deca::f,
-                                 &Deca::g,
-                                 &Deca::h,
-                                 &Deca::i,
-                                 &Deca::j>)[da + db + dc + dd + de
-                                                + df + dg + dh + di
-                                            == dj]
+  PTN_BIND(Deca, a, b, c, d, e, f, g, h, i, j);
+  Deca dc{1, 1, 1, 1, 1, 1, 1, 1, 1, 9};
+  auto result = ptn::match(dc)
+                | ptn::on(
+                    ptn::$(ptn::has<&Deca::a,
+                                    &Deca::b,
+                                    &Deca::c,
+                                    &Deca::d,
+                                    &Deca::e,
+                                    &Deca::f,
+                                    &Deca::g,
+                                    &Deca::h,
+                                    &Deca::i,
+                                    &Deca::j>)[a + b + c + d + e + f
+                                                   + g + h + i
+                                               == j]
                         >> 1,
                     ptn::_ >> 0);
   EXPECT_EQ(result, 1);
 }
 
 TEST(NamedPlaceholder, TenMemberGuardFails) {
-  Deca d{1, 1, 1, 1, 1, 1, 1, 1, 1, 10};
-  auto result = ptn::match(d)
-                | PTN_ON(
-                    ptn::$(
-                        ptn::has<&Deca::a,
-                                 &Deca::b,
-                                 &Deca::c,
-                                 &Deca::d,
-                                 &Deca::e,
-                                 &Deca::f,
-                                 &Deca::g,
-                                 &Deca::h,
-                                 &Deca::i,
-                                 &Deca::j>)[da + db + dc + dd + de
-                                                + df + dg + dh + di
-                                            == dj]
+  PTN_BIND(Deca, a, b, c, d, e, f, g, h, i, j);
+  Deca dc{1, 1, 1, 1, 1, 1, 1, 1, 1, 10};
+  auto result = ptn::match(dc)
+                | ptn::on(
+                    ptn::$(ptn::has<&Deca::a,
+                                    &Deca::b,
+                                    &Deca::c,
+                                    &Deca::d,
+                                    &Deca::e,
+                                    &Deca::f,
+                                    &Deca::g,
+                                    &Deca::h,
+                                    &Deca::i,
+                                    &Deca::j>)[a + b + c + d + e + f
+                                                   + g + h + i
+                                               == j]
                         >> 1,
                     ptn::_ >> 0);
   EXPECT_EQ(result, 0);


### PR DESCRIPTION
**Summary**

Upgrade `PTN_BIND` placeholders from positional (`arg_t<N>`) to member-anchored (`member_t<&Type::name>`). Guards attached to `has<...>` rewrite each name to the position of its member in the pattern's member list at compile time, so names follow members — the order of member pointers in `has<...>` no longer matters. This also activates the previously documentary `Type` argument and resolves the deferred Type-validation roadmap item without static reflection.

**Changes**

- `PTN_BIND(Type, ...)` now expands each name to `constexpr member_t<&Type::name>`; misspelled member names fail right at the macro line.
- New compile-time machinery in `guard.hpp`: `member_position` (skips `_ign` slots) + `resolve_expr`/`resolve_pred` expression-tree rewriting; evaluation machinery untouched.
- Resolution hooks: `has_pattern::operator[]` (non-binding path) and a new `guard_resolver` hook in `binding_base.hpp`, specialized for `structural_bind_pattern` (binding path).
- `_` keeps its positional meaning and mixes freely with member names.
- Clear static_asserts when a name is missing from `has<...>` or used on a non-structural pattern.
- Docs: `docs/api.md` `PTN_BIND` section rewritten (member semantics + `PTN_ON` capture caveat); roadmap WIP entry added and the deferred validation item marked resolved.

**Testing**

- `tests_named_placeholder.cpp` rewritten for member semantics: type checks assert `member_t<&T::m>`; new cases cover order independence (`has<&P::y, &P::x>`), `_ign` slot skipping, mixed `_` + member names, and the non-binding `has<>[guard]` path. Block-scope binds use `ptn::on` because `PTN_ON`'s captureless caching lambda cannot capture block-scope names.
- `tests_destructure.cpp` migrated from alias names to member names.
- New compile-fail cases, each verified to fail with the intended diagnostic: `member_placeholder_not_in_pattern`, `member_placeholder_non_structural`, `ptn_bind_unknown_member`.
- Full suite: **191/191** passing locally (GCC 13 + Clang 20, C++17).
- clang-format clean on all touched files.

**Notes**

- **Breaking** for alias-style `PTN_BIND` usage (placeholder names that were not real members): such declarations now fail at the macro line. Member-named usage is source-compatible with identical semantics when written in matching order.