### PR TITLE
feat(dsl): allow block-scope PTN_BIND names inside PTN_ON

### DIFF
--- a/docs/api.md
+++ b/docs/api.md
@@ -241,9 +241,8 @@ $[rng(0, 10, pat::mod::open)]
 scope. Use callables for domain logic that does not read naturally as `_` or a
 short named-placeholder expression.
 
-Note: block-scope names cannot be referenced inside `PTN_ON`, because its
-caching lambda cannot capture them. Use plain `on(...)` there, or declare the
-names at namespace scope.
+Block-scope declarations use static storage duration, so they can also be
+referenced inside `PTN_ON`'s captureless caching lambda.
 
 ### Migration from positional guard APIs
 

--- a/include/ptn/patternia.hpp
+++ b/include/ptn/patternia.hpp
@@ -120,8 +120,11 @@ namespace ptn {
 // - PTN_BIND_N is defined by chaining: it expands to
 //   PTN_BIND_{N-1} plus one more declaration, so adding a new
 //   arity only costs one short macro instead of a full rewrite.
+// The static storage duration lets block-scope declarations appear
+// inside PTN_ON's captureless caching lambda: only automatic
+// variables require captures; statics do not.
 #define PTN_BIND_DECL(Type, name)                                   \
-  constexpr ::ptn::pat::mod::member_t<&Type::name> name{};
+  static constexpr ::ptn::pat::mod::member_t<&Type::name> name{};
 
 #define PTN_BIND_1(Type, m0) PTN_BIND_DECL(Type, m0)
 

--- a/tests/tests_named_placeholder.cpp
+++ b/tests/tests_named_placeholder.cpp
@@ -333,6 +333,38 @@ TEST(NamedPlaceholder, GuardOnTypePatternRejects) {
 }
 
 // =========================================================================
+// PTN_ON: block-scope names have static storage duration, so the
+// captureless caching lambda can reference them.
+// =========================================================================
+
+TEST(NamedPlaceholder, BlockScopeNamesWorkInsidePtnOn) {
+  PTN_BIND(Point, x, y);
+  auto on_circle = [](const Point &p) {
+    return ptn::match(p)
+           | PTN_ON(ptn::$(ptn::has<&Point::x,
+                                    &Point::y>)[x * x + y * y == 25]
+                        >> 1,
+                    ptn::_ >> 0);
+  };
+  EXPECT_EQ(on_circle(Point{3, 4}), 1);
+  EXPECT_EQ(on_circle(Point{1, 2}), 0);
+}
+
+TEST(NamedPlaceholder, RepeatedNamesInsidePtnOn) {
+  PTN_BIND(Point, x, y);
+  auto on_diagonal = [](const Point &p) {
+    return ptn::match(p)
+           | PTN_ON(
+               ptn::$(ptn::has<&Point::x, &Point::y>)[x * x == y * y]
+                   >> 1,
+               ptn::_ >> 0);
+  };
+  EXPECT_EQ(on_diagonal(Point{3, 3}), 1);
+  EXPECT_EQ(on_diagonal(Point{3, -3}), 1);
+  EXPECT_EQ(on_diagonal(Point{3, 4}), 0);
+}
+
+// =========================================================================
 // Arithmetic expressions in guards (not just comparisons).
 // =========================================================================
 


### PR DESCRIPTION
**Summary**

Block-scope `PTN_BIND` declarations can now be referenced inside `PTN_ON`. Previously this failed to compile: `PTN_ON`'s caching lambda is captureless by design, and passing a placeholder to the guard operators odr-used it, forcing a capture. The fix is one word — give the declarations `static` storage duration. `PTN_ON` itself is unchanged.

**Changes**

- `PTN_BIND_DECL` now expands to `static constexpr member_t<&Type::name>`. Captures are only required for automatic variables, so statics are freely usable inside the captureless lambda — for any expression shape, including repeated names (`x * x == y * y`), which failed on both GCC and Clang before.
- `docs/api.md`: replace the former block-scope/`PTN_ON` caveat (added in #47) with the new guarantee.

**Testing**

- New tests `BlockScopeNamesWorkInsidePtnOn` and `RepeatedNamesInsidePtnOn`: arithmetic guards with repeated names inside `PTN_ON`, including a second call exercising the cached static case pack. Verified with GCC 13 + Clang 20 in C++17 mode.
- Full suite: **195/195** passing.
- The `static_on_with_capture` compile-fail guard still passes — `PTN_ON`'s captureless design is untouched.