### PR TITLE
feat(pattern): add operator sugar for combinators

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,12 @@ std::string describe(const Value &v) {
 // Negation: match values NOT equal to specific literals
 int status = 404;
 auto msg = match(status) | on(
-    neg(val<200>) >> []{ return std::string("error"); },
-    _             >> []{ return std::string("ok"); }
+    !val<200> >> []{ return std::string("error"); },
+    _          >> []{ return std::string("ok"); }
 );
 // msg == "error" — status isn't 200
+// `!p` is sugar for neg(p); likewise (a || b) for any and
+// (a && b) for all.
 ```
 
 ## Installation

--- a/docs/api.md
+++ b/docs/api.md
@@ -344,6 +344,8 @@ Properties:
 - Sub-patterns are evaluated left-to-right; evaluation stops at the first
   match.
 - Requires at least one sub-pattern; every argument must be a pattern object.
+- Operator sugar: `(a || b)` is equivalent to `any(a, b)`. Note that `>>`
+  binds tighter than `||`, so parenthesize: `(lit(1) || lit(2)) >> handler`.
 
 ### `all(ps...)`
 
@@ -363,6 +365,8 @@ Properties:
 - Sub-patterns are evaluated left-to-right; evaluation stops at the first
   mismatch.
 - Requires at least one sub-pattern; every argument must be a pattern object.
+- Operator sugar: `(a && b)` is equivalent to `all(a, b)`. Note that `>>`
+  binds tighter than `&&`, so parenthesize: `(p && q) >> handler`.
 
 ### `neg(p)`
 
@@ -381,6 +385,12 @@ Properties:
 - Non-binding: handlers receive zero arguments.
 - Accepts exactly one sub-pattern (no zero- or multi-argument form).
 - `neg(neg(p))` restores the original match behavior (double negation cancels).
+- Operator sugar: `!p` is equivalent to `neg(p)` and needs no parentheses:
+  `!val<200> >> "error"`.
+
+The pattern-level operators only accept pattern operands, so they never
+collide with the guard-level `&&` / `||` (which keep their `pred_and` /
+`pred_or` meaning inside `[...]` guards).
 
 ---
 

--- a/docs/roadmap.md
+++ b/docs/roadmap.md
@@ -71,6 +71,16 @@ without static reflection.
 
 ---
 
+### Pattern operator sugar — `!p`, `(a || b)`, `(a && b)`
+
+Operator forms of the combinators: `!p` for `neg(p)`, `(a || b)` for
+`any(a, b)`, and `(a && b)` for `all(a, b)`. The overloads live in
+`ptn::pat::base` so ADL finds them for every pattern via the shared
+`pattern_base` base class, and they reject guard predicates so the
+guard-level `&&` / `||` semantics are untouched.
+
+---
+
 ## NEXT
 
 Potential follow-up items after current WIP scope is stabilized.

--- a/include/ptn/pattern/combinator.hpp
+++ b/include/ptn/pattern/combinator.hpp
@@ -12,6 +12,7 @@
 
 #include "ptn/pattern/base/fwd.h"
 #include "ptn/pattern/base/pattern_base.hpp"
+#include "ptn/pattern/base/pattern_traits.hpp"
 
 namespace ptn::pat {
 
@@ -20,11 +21,13 @@ namespace ptn::pat {
     // Matches when any sub-pattern matches. This combinator never
     // contributes bindings; it is used only for control flow.
     template <typename... Patterns>
-    struct any_pattern : base::pattern_base<any_pattern<Patterns...>> {
+    struct any_pattern
+        : base::pattern_base<any_pattern<Patterns...>> {
       std::tuple<Patterns...> patterns;
 
       template <typename... Ps,
-                typename = std::enable_if_t<sizeof...(Ps) == sizeof...(Patterns)>>
+                typename = std::enable_if_t<sizeof...(Ps)
+                                            == sizeof...(Patterns)>>
       constexpr explicit any_pattern(Ps &&...ps)
           : patterns(std::forward<Ps>(ps)...) {
       }
@@ -49,11 +52,13 @@ namespace ptn::pat {
     // Matches only when every sub-pattern matches. Like any_pattern,
     // this combinator is non-binding.
     template <typename... Patterns>
-    struct all_pattern : base::pattern_base<all_pattern<Patterns...>> {
+    struct all_pattern
+        : base::pattern_base<all_pattern<Patterns...>> {
       std::tuple<Patterns...> patterns;
 
       template <typename... Ps,
-                typename = std::enable_if_t<sizeof...(Ps) == sizeof...(Patterns)>>
+                typename = std::enable_if_t<sizeof...(Ps)
+                                            == sizeof...(Patterns)>>
       constexpr explicit all_pattern(Ps &&...ps)
           : patterns(std::forward<Ps>(ps)...) {
       }
@@ -85,7 +90,8 @@ namespace ptn::pat {
         sizeof...(Patterns) > 0,
         "[Patternia.any]: requires at least one sub-pattern.");
     static_assert(
-        (std::is_base_of_v<base::pattern_tag, std::decay_t<Patterns>> && ...),
+        (std::is_base_of_v<base::pattern_tag, std::decay_t<Patterns>>
+         && ...),
         "[Patternia.any]: every argument must be a pattern object.");
 
     return detail::any_pattern<std::decay_t<Patterns>...>(
@@ -100,7 +106,8 @@ namespace ptn::pat {
         sizeof...(Patterns) > 0,
         "[Patternia.all]: requires at least one sub-pattern.");
     static_assert(
-        (std::is_base_of_v<base::pattern_tag, std::decay_t<Patterns>> && ...),
+        (std::is_base_of_v<base::pattern_tag, std::decay_t<Patterns>>
+         && ...),
         "[Patternia.all]: every argument must be a pattern object.");
 
     return detail::all_pattern<std::decay_t<Patterns>...>(
@@ -111,13 +118,55 @@ namespace ptn::pat {
 
 namespace ptn::pat::base {
 
+  namespace detail {
+
+    // Both operands must be patterns and neither may be a guard
+    // predicate: `&&` / `||` between guard predicates keep their
+    // existing pred_and / pred_or meaning.
+    template <typename L, typename R>
+    inline constexpr bool pattern_pair_v =
+        std::is_base_of_v<pattern_tag, std::decay_t<L>>
+        && std::is_base_of_v<pattern_tag, std::decay_t<R>>
+        && !pat::traits::is_guard_predicate_v<std::decay_t<L>>
+        && !pat::traits::is_guard_predicate_v<std::decay_t<R>>;
+
+  } // namespace detail
+
+  // Operator sugar: `a || b` is equivalent to `any(a, b)`.
+  //
+  // Declared in ptn::pat::base so ADL finds it for every pattern
+  // via the shared pattern_base base class (concrete patterns live
+  // in ptn::pat::detail, and ADL does not ascend namespaces).
+  //
+  // NOTE: `>>` binds tighter than `||`, so parenthesize the
+  // pattern in a case: `(lit(1) || lit(2)) >> handler`.
+  template <typename L,
+            typename R,
+            std::enable_if_t<detail::pattern_pair_v<L, R>, int> = 0>
+  constexpr auto operator||(L &&l, R &&r) {
+    return pat::any(std::forward<L>(l), std::forward<R>(r));
+  }
+
+  // Operator sugar: `a && b` is equivalent to `all(a, b)`.
+  //
+  // NOTE: `>>` binds tighter than `&&`, so parenthesize the
+  // pattern in a case: `(p && q) >> handler`.
+  template <typename L,
+            typename R,
+            std::enable_if_t<detail::pattern_pair_v<L, R>, int> = 0>
+  constexpr auto operator&&(L &&l, R &&r) {
+    return pat::all(std::forward<L>(l), std::forward<R>(r));
+  }
+
   template <typename... Patterns, typename Subject>
-  struct binding_args<ptn::pat::detail::any_pattern<Patterns...>, Subject> {
+  struct binding_args<ptn::pat::detail::any_pattern<Patterns...>,
+                      Subject> {
     using type = std::tuple<>;
   };
 
   template <typename... Patterns, typename Subject>
-  struct binding_args<ptn::pat::detail::all_pattern<Patterns...>, Subject> {
+  struct binding_args<ptn::pat::detail::all_pattern<Patterns...>,
+                      Subject> {
     using type = std::tuple<>;
   };
 

--- a/include/ptn/pattern/negation.hpp
+++ b/include/ptn/pattern/negation.hpp
@@ -5,6 +5,8 @@
 #include <utility>
 
 #include "ptn/pattern/base/fwd.h"
+#include "ptn/pattern/base/pattern_base.hpp"
+#include "ptn/pattern/base/pattern_traits.hpp"
 
 namespace ptn::pat {
 
@@ -45,5 +47,23 @@ namespace ptn::pat::base {
                       Subject> {
     using type = std::tuple<>;
   };
+
+  // Operator sugar: `!p` is equivalent to `neg(p)`. Only pattern
+  // objects participate; guard predicates are excluded so this
+  // never collides with boolean logic over predicates.
+  //
+  // Declared in ptn::pat::base so ADL finds it for every pattern:
+  // all patterns derive from base::pattern_base, which makes this
+  // namespace associated even though the concrete pattern types
+  // live in ptn::pat::detail (ADL does not ascend namespaces).
+  template <
+      typename P,
+      std::enable_if_t<
+          std::is_base_of_v<pattern_tag, std::decay_t<P>>
+              && !pat::traits::is_guard_predicate_v<std::decay_t<P>>,
+          int> = 0>
+  constexpr auto operator!(P &&p) {
+    return pat::neg(std::forward<P>(p));
+  }
 
 } // namespace ptn::pat::base

--- a/tests/tests_combinator.cpp
+++ b/tests/tests_combinator.cpp
@@ -336,3 +336,88 @@ TEST(NegationPattern, NegNegIsIdentity) {
                     _ >> [] { return 0; }),
             42);
 }
+
+// =========================================================================
+// Operator sugar: !p == neg(p), (a || b) == any(a, b),
+// (a && b) == all(a, b).
+// =========================================================================
+
+TEST(OperatorSugar, NegationIsNeg) {
+  static_assert(
+      std::is_same_v<decltype(!lit(1)), decltype(neg(lit(1)))>);
+}
+
+TEST(OperatorSugar, BangMatchesNeg) {
+  int a = 5, b = 1;
+  EXPECT_EQ(match(a) | on(!lit(1) >> 1, _ >> 0), 1);
+  EXPECT_EQ(match(b) | on(!lit(1) >> 1, _ >> 0), 0);
+}
+
+TEST(OperatorSugar, BangOnVal) {
+  int a = 404, b = 200;
+  EXPECT_EQ(match(a) | on(!val<200> >> 1, _ >> 0), 1);
+  EXPECT_EQ(match(b) | on(!val<200> >> 1, _ >> 0), 0);
+}
+
+TEST(OperatorSugar, OrIsAny) {
+  int a = 2, b = 3;
+  // NOTE: `>>` binds tighter than `||`, hence the parentheses.
+  EXPECT_EQ(match(a) | on((lit(1) || lit(2)) >> 1, _ >> 0), 1);
+  EXPECT_EQ(match(b) | on((lit(1) || lit(2)) >> 1, _ >> 0), 0);
+}
+
+TEST(OperatorSugar, OrChainsLeft) {
+  int a = 3, b = 4;
+  EXPECT_EQ(match(a) | on((lit(1) || lit(2) || lit(3)) >> 1, _ >> 0),
+            1);
+  EXPECT_EQ(match(b) | on((lit(1) || lit(2) || lit(3)) >> 1, _ >> 0),
+            0);
+}
+
+TEST(OperatorSugar, AndIsAll) {
+  auto is_even = [](int x) { return x % 2 == 0; };
+  int  a = 6, b = 2, c = 5;
+  EXPECT_EQ(match(a) | on((pred(is_even) && !lit(2)) >> 1, _ >> 0),
+            1);
+  EXPECT_EQ(match(b) | on((pred(is_even) && !lit(2)) >> 1, _ >> 0),
+            0);
+  EXPECT_EQ(match(c) | on((pred(is_even) && !lit(2)) >> 1, _ >> 0),
+            0);
+}
+
+TEST(OperatorSugar, DoubleBangIsIdentity) {
+  int a = 1, b = 2;
+  EXPECT_EQ(match(a) | on(!!lit(1) >> 1, _ >> 0), 1);
+  EXPECT_EQ(match(b) | on(!!lit(1) >> 1, _ >> 0), 0);
+}
+
+TEST(OperatorSugar, GuardOperatorsUnaffected) {
+  // `&&` / `||` between guard predicates keep pred_and / pred_or
+  // semantics; the pattern-level sugar must not interfere.
+  int a = 50, b = 150;
+  EXPECT_EQ(match(a) | on($[(_ > 0) && (_ < 100)] >> 1, _ >> 0), 1);
+  EXPECT_EQ(match(b) | on($[(_ < 0) || (_ > 100)] >> 1, _ >> 0), 1);
+}
+
+TEST(OperatorSugar, MixedWithTypePatterns) {
+  // The sugar composes patterns of different kinds against one
+  // subject (here: two type patterns over a variant).
+  std::variant<int, std::string, double> a = 1;
+  std::variant<int, std::string, double> b = std::string("s");
+  std::variant<int, std::string, double> c = 1.5;
+  EXPECT_EQ(
+      match(a)
+          | on((is<int> || is<std::string>) >> [] { return 1; },
+               _ >> 0),
+      1);
+  EXPECT_EQ(
+      match(b)
+          | on((is<int> || is<std::string>) >> [] { return 1; },
+               _ >> 0),
+      1);
+  EXPECT_EQ(
+      match(c)
+          | on((is<int> || is<std::string>) >> [] { return 1; },
+               _ >> 0),
+      0);
+}


### PR DESCRIPTION
**Summary**

Add operator forms for the pattern combinators: `!p` for `neg(p)`, `(a || b)` for `any(a, b)`, and `(a && b)` for `all(a, b)`. The pattern algebra now reads like the boolean logic it models.

```cpp
match(status) | on(
  !val<200>                  >> "error",
  (lit(301) || lit(302))     >> "redirect",
  (pred(is_json) && !lit(0)) >> "json payload",
  _                          >> "ok"
);
```

**Changes**

- `negation.hpp`: `operator!` equivalent to `neg(p)`.
- `combinator.hpp`: `operator||` equivalent to `any(a, b)`; `operator&&` equivalent to `all(a, b)`.
- The overloads are declared in `ptn::pat::base`: every pattern derives from `pattern_base`, which makes that namespace ADL-associated for all pattern types. (Concrete patterns live in `ptn::pat::detail`, and ADL does not ascend enclosing namespaces — declaring the operators in `ptn::pat` would make them unfindable.)
- Operands are constrained to patterns that are **not** guard predicates, so guard-level `&&` / `||` inside `[...]` keep their `pred_and` / `pred_or` semantics — verified by test.
- Docs: `docs/api.md` combinator sections, roadmap WIP entry, README negation example.

**Testing**

- Nine new cases in `tests_combinator.cpp`: type identity of `!p` vs `neg(p)`, or/and/chained-or/double-bang behavior, sugar mixing pattern kinds (`is<int> || is<std::string>`), and guard-operator non-interference.
- Full suite: **204/204** passing locally (Clang 20, C++17).
- One caveat, documented: `>>` binds tighter than `||`/`&&`, so combined patterns need parentheses in a case — `(lit(1) || lit(2)) >> handler`. Unary `!` needs none.